### PR TITLE
set option to recursively clone submodules

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
@@ -31,6 +31,7 @@ public class CloneOperation extends GitOperation {
     public CloneOperation setCommand(String uri) {
         this.command = Git.cloneRepository().
                 setCloneAllBranches(true).
+                setCloneSubmodules(true).
                 setDirectory(repository.getWorkTree()).
                 setURI(uri);
         return this;


### PR DESCRIPTION
From the JGit documentation, the `CloneCommand` supports a `setCloneSubmodules` method that  implements the `git clone --recurse-submodules` logic. 

There is one caveat with the submodules support in JGit. I found this bug tracker https://bugs.eclipse.org/bugs/show_bug.cgi?id=470318 regarding a bug on `SubmoduleUpdateCommand` on an existing cloned repository. I was initially thinking of adding a `SubmoduleUpdateCommand` to the `PullOperation`, which would allow the password store to also pull updates to the submodules. As it stands now, this will only allow the initial clone of a submodule, but is missing support for fetching updates. The JGit bug is now fixed, so we could add to the `PullOperation`, but we would have to upgrade JGit versions. 