### PR TITLE
Correct Git Utils Layout

### DIFF
--- a/app/src/main/res/layout/activity_git_config.xml
+++ b/app/src/main/res/layout/activity_git_config.xml
@@ -92,6 +92,7 @@
         android:layout_width="344dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
         android:background="@drawable/bottom_line"
         android:gravity="start"
         android:paddingBottom="6dp"


### PR DESCRIPTION
For whatever reason, the line "Hackish tools" is centered because the left margin is missing.  This alignment made me itch today, so I figured I would just fix it.