### PR TITLE
Re-add OpenPgpAppPreference

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,10 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
 android {
     defaultConfig {
         applicationId 'com.zeapo.pwdstore'
@@ -76,7 +80,7 @@ dependencies {
     implementation 'com.google.android.material:material:' + versions.material
     implementation 'androidx.annotation:annotation:' + versions.annotation
     implementation 'androidx.biometric:biometric:' + versions.biometric
-    implementation 'org.sufficientlysecure:openpgp-api:' + versions.openpgp
+    implementation 'com.github.msfjarvis:openpgp-api:' + versions.openpgp
     implementation('org.eclipse.jgit:org.eclipse.jgit:' + versions.jgit) {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -40,11 +40,9 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory android:title="@string/pref_crypto_title">
-        <!-- TODO(msf): Update the damn library and re-enable this
-        <org.openintents.openpgp.util.OpenPgpAppPreference
+        <org.openintents.openpgp.util.OpenPgpAppPreference2
             android:key="openpgp_provider_list"
             android:title="@string/pref_provider_title" />
-        -->
         <androidx.preference.Preference
             android:key="openpgp_key_id_pref"
             android:title="@string/pref_key_title" />

--- a/versions.gradle
+++ b/versions.gradle
@@ -35,7 +35,7 @@ ext {
         commons_codec: '1.13',
         jgit: '3.7.1.201504261725-r',
         jsch: '0.1.55',
-        openpgp: '12.0',
+        openpgp: 'v14',
         sshauth: '1.0'
     ]
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Since the OpenKeychain developers are amazingly ignorant of Android's deprecation of framework preferences and the rise of AndroidX, I've had to [fork their library](https://github.com/msfjarvis/openpgp-api) to create an AndroidX-compatible preference for selecting the app OpenPGP provider. It's not as ugly as theirs, but does the trick. I'm currently using a built aar rather than maven dependency because Jitpack appears to be having some trouble and I wanna complete my rewrite so I'll take this time to finish that then PR it upstream so it can be ignored by the developers.

## :bulb: Motivation and Context
Not having the preference breaks core functionality for us.

## :green_heart: How did you test it?
Manual testing of decryption/encryption operations

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->