### PR TITLE
Add option to show hidden folders

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -210,13 +210,7 @@ open class PasswordRepository protected constructor() {
 
             if (passList.size == 0) return passwordList
             if (showHiddenDirs) {
-                passList.filter {
-                    val hidden = it.isHidden
-                    when {
-                        it.isFile && hidden -> false
-                        else -> true
-                    }
-                }.toCollection(passList.apply { clear() })
+                passList.filter { !(it.isFile && it.isHidden) }.toCollection(passList.apply { clear() })
             } else {
                 passList.filter { !it.isHidden }.toCollection(passList.apply { clear() })
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,4 +274,6 @@
     <string name="access_sdcard_text">The store is on the sdcard but the app does not have permission to access it. Please give permission.</string>
     <string name="your_public_key">Your public key</string>
     <string name="error_generate_ssh_key">Error while trying to generate the ssh-key</string>
+    <string name="pref_show_hidden_title">Show hidden folders</string>
+    <string name="pref_show_hidden_summary">Include hidden directories in the password list</string>
 </resources>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -90,6 +90,12 @@
             android:entryValues="@array/sort_order_values"
             android:persistent="true" />
         <androidx.preference.SwitchPreferenceCompat
+            android:title="@string/pref_show_hidden_title"
+            android:summary="@string/pref_show_hidden_summary"
+            android:key="show_hidden_folders"
+            android:defaultValue="false"
+            android:persistent="true" />
+        <androidx.preference.SwitchPreferenceCompat
             android:key="biometric_auth"
             android:title="@string/biometric_auth_title"
             android:summary="@string/biometric_auth_summary" />


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds option to show hidden folders in the password list

## :bulb: Motivation and Context
As detailed in #446, there are legitimate usecases where this is a requirement and thus an option is desirable.

## :green_heart: How did you test it?
Manually create hidden files and folders and confirm visibility is as expected with the option enabled/disabled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->