### PR TITLE
Prevent an activity loop when no OpenPGP Provider is selected

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -29,6 +29,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import androidx.preference.SwitchPreferenceCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.autofill.AutofillPreferenceActivity
 import com.zeapo.pwdstore.crypto.PgpActivity
 import com.zeapo.pwdstore.git.GitActivity
@@ -126,10 +127,16 @@ class UserPreference : AppCompatActivity() {
             appVersionPreference?.summary = "Version: ${BuildConfig.VERSION_NAME}"
 
             keyPreference?.onPreferenceClickListener = ClickListener {
-                val intent = Intent(callingActivity, PgpActivity::class.java)
-                intent.putExtra("OPERATION", "GET_KEY_ID")
-                startActivityForResult(intent, IMPORT_PGP_KEY)
-                true
+                val providerPackageName = requireNotNull(sharedPreferences.getString("openpgp_provider_list", ""))
+                if (providerPackageName.isEmpty()) {
+                    Snackbar.make(requireView(), resources.getString(R.string.provider_toast_text), Snackbar.LENGTH_LONG).show()
+                    false
+                } else {
+                    val intent = Intent(callingActivity, PgpActivity::class.java)
+                    intent.putExtra("OPERATION", "GET_KEY_ID")
+                    startActivityForResult(intent, IMPORT_PGP_KEY)
+                    true
+                }
             }
 
             sshKeyPreference?.onPreferenceClickListener = ClickListener {


### PR DESCRIPTION
Signed-off-by: Aditya Wasan <adityawasan55@gmail.com>

## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
When no OpenPGP provider is selected from the list, the settings activity opens PgPActivity which again opens Settings. This prevented the user from seeing snackbar and added multiple instances of settings activity to the back stack.


## :bulb: Motivation and Context
Improves app flow. 


## :green_heart: How did you test it?
When no OpenPGP provider is selected, the settings activity now show snackbar and do not launch PGP activity. However when it is selected it launches the OpenKeychain application for me.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
