### PR TITLE
Also count subdirectories in child count

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
@@ -21,7 +21,7 @@ import java.util.TreeSet
 
 abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<PasswordItem>) : RecyclerView.Adapter<EntryRecyclerAdapter.ViewHolder>() {
     internal val selectedItems: MutableSet<Int> = TreeSet()
-    private lateinit var settings: SharedPreferences
+    internal var settings: SharedPreferences? = null
 
     // Return the size of your dataset (invoked by the layout manager)
     override fun getItemCount(): Int {
@@ -79,11 +79,9 @@ abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<P
 
     // Replace the contents of a view (invoked by the layout manager)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        settings = settings ?: PreferenceManager.getDefaultSharedPreferences(holder.view.context.applicationContext)
         val pass = values[position]
-        if (!::settings.isInitialized) {
-            settings = PreferenceManager.getDefaultSharedPreferences(holder.view.context.applicationContext)
-        }
-        val showHidden = settings.getBoolean("show_hidden_folders", false)
+        val showHidden = settings?.getBoolean("show_hidden_folders", false) ?: false
         holder.name.text = pass.toString()
         if (pass.type == PasswordItem.TYPE_CATEGORY) {
             holder.type.visibility = View.GONE

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
@@ -4,11 +4,13 @@
  */
 package com.zeapo.pwdstore.ui.adapters
 
+import android.content.SharedPreferences
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.utils.PasswordItem
@@ -19,6 +21,7 @@ import java.util.TreeSet
 
 abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<PasswordItem>) : RecyclerView.Adapter<EntryRecyclerAdapter.ViewHolder>() {
     internal val selectedItems: MutableSet<Int> = TreeSet()
+    private lateinit var settings: SharedPreferences
 
     // Return the size of your dataset (invoked by the layout manager)
     override fun getItemCount(): Int {
@@ -77,12 +80,19 @@ abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<P
     // Replace the contents of a view (invoked by the layout manager)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val pass = values[position]
+        if (!::settings.isInitialized) {
+            settings = PreferenceManager.getDefaultSharedPreferences(holder.view.context.applicationContext)
+        }
+        val showHidden = settings.getBoolean("show_hidden_folders", false)
         holder.name.text = pass.toString()
         if (pass.type == PasswordItem.TYPE_CATEGORY) {
             holder.type.visibility = View.GONE
             holder.typeImage.setImageResource(R.drawable.ic_multiple_files_24dp)
             holder.folderIndicator.visibility = View.VISIBLE
-            val childCount = (pass.file.list() ?: emptyArray<File>()).size
+            val children = pass.file.listFiles { pathname ->
+                !(!showHidden && (pathname.isDirectory && pathname.isHidden))
+            } ?: emptyArray<File>()
+            val childCount = children.size
             if (childCount > 0) {
                 holder.childCount.visibility = View.VISIBLE
                 holder.childCount.text = "$childCount"

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
@@ -82,7 +82,7 @@ abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<P
             holder.type.visibility = View.GONE
             holder.typeImage.setImageResource(R.drawable.ic_multiple_files_24dp)
             holder.folderIndicator.visibility = View.VISIBLE
-            val childCount = (pass.file.list { current, name -> File(current, name).isFile } ?: emptyArray<File>()).size
+            val childCount = (pass.file.list() ?: emptyArray<File>()).size
             if (childCount > 0) {
                 holder.childCount.visibility = View.VISIBLE
                 holder.childCount.text = "$childCount"


### PR DESCRIPTION
This should have been a part of #571 but was overlooked

Link: https://github.com/android-password-store/Android-Password-Store/issues/559#issuecomment-553506052

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
We should have always been counting subdirectories here

## :bulb: Motivation and Context
@AluminiumTank pointed out correctly in the original issue that the heuristics for the child count were lacking.

## :green_heart: How did you test it?
Visual test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->