### PR TITLE
Add full path open in autofill dialog (#609)

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -92,10 +92,12 @@ class UserPreference : AppCompatActivity() {
             val autoFillAppsPreference = findPreference<Preference>("autofill_apps")
             val autoFillDefaultPreference = findPreference<CheckBoxPreference>("autofill_default")
             val autoFillAlwaysShowDialogPreference = findPreference<CheckBoxPreference>("autofill_always")
+            val autoFillShowFullNamePreference = findPreference<CheckBoxPreference>("autofill_full_path")
             autofillDependencies = listOf(
                     autoFillAppsPreference,
                     autoFillDefaultPreference,
-                    autoFillAlwaysShowDialogPreference
+                    autoFillAlwaysShowDialogPreference,
+                    autoFillShowFullNamePreference
             )
 
             // Misc preferences

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
@@ -411,7 +411,14 @@ class AutofillService : AccessibilityService() {
         // make it optional (or make height a setting for the same effect)
         val itemNames = arrayOfNulls<CharSequence>(items.size + 2)
         for (i in items.indices) {
-            itemNames[i] = items[i].name.replace(".gpg", "")
+            if (settings!!.getBoolean("autofill_full_path", false)) {
+                itemNames[i] = items[i].path.replace(".gpg", "")
+                        .replace(
+                                PasswordRepository.getRepositoryDirectory(applicationContext).toString() + "/",
+                                "")
+            } else {
+                itemNames[i] = items[i].name.replace(".gpg", "")
+            }
         }
         itemNames[items.size] = getString(R.string.autofill_pick)
         itemNames[items.size + 1] = getString(R.string.autofill_pick_and_match)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,8 @@
     <string name="pref_autofill_default_title">Automatically match by default</string>
     <string name="pref_autofill_default_hint">Default to \'Automatically match\' for apps without custom settings. Otherwise, \'Never match.\'</string>
     <string name="pref_autofill_always_title">Always show dialog</string>
+    <string name="pref_autofill_full_path_title">Show Full Path</string>
+    <string name="pref_autofill_full_path_hint">Show full path of matching password files</string>
     <string name="pref_misc_title">Misc</string>
     <string name="pref_clear_clipboard_title">Clear clipboard 20 times</string>
     <string name="pref_clear_clipboard_hint">Store consecutive numbers in the clipboard 20 times. Useful on Samsung phones that feature clipboard history.</string>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -118,6 +118,11 @@
             android:defaultValue="false"
             android:key="autofill_always"
             android:title="@string/pref_autofill_always_title"/>
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="autofill_full_path"
+            android:summary="@string/pref_autofill_full_path_hint"
+            android:title="@string/pref_autofill_full_path_title"/>
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory android:title="@string/pref_misc_title">


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds a setting to the autofill section to allow the autofill dialog to print full paths of matching password files.


## :bulb: Motivation and Context
https://github.com/android-password-store/Android-Password-Store/issues/609

## :green_heart: How did you test it?
See screenshots.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
Autofill dialog seems broken in portrait, the window is too small to see anything.


## :camera_flash: Screenshots / GIFs
Current/default behavior:
<img src="https://i.imgur.com/NL5k9F2.png" width="260">&emsp;

New behavior:
<img src="https://i.imgur.com/UJNPQUm.png" width="260">&emsp;
<img src="https://i.imgur.com/FvjVRHD.png" width="260">
