### PR TITLE
Fix autofill window size (#611)

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
@@ -18,6 +18,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
@@ -440,12 +441,12 @@ class AutofillService : AccessibilityService() {
         dialog = builder.create()
         setDialogType(dialog)
         dialog?.window?.apply {
-            val height = 200
             val density = context.resources.displayMetrics.density
             addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+            setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
             clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             // arbitrary non-annoying size
-            setLayout((240 * density).toInt(), (height * density).toInt())
+            setLayout((340 * density).toInt(), WRAP_CONTENT)
         }
         dialog?.show()
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Change sizing of autofill dialog to be more reasonable


## :bulb: Motivation and Context
Autofill window in master is nearly unusable due to its small size


## :green_heart: How did you test it?
See screenshots

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
Current behavior:
<img src="https://imgur.com/lEdzrJy.png" width="260">&emsp;
<img src="https://imgur.com/mr0J5Kl.png" width="260">&emsp;

New behavior:
<img src="https://imgur.com/orUdOgg.png" width="260">&emsp;
<img src="https://imgur.com/zDw8vDc.gif" width="260">&emsp;
<img src="https://imgur.com/RSj0VEV.png" width="260">&emsp;
