### PR TITLE
Correctly unmarshal errors from OpenKeychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.4.0] - TBD
+## Unreleased
+
+### Fixed
+- OpenKeychain errors cause app crash
+
+## [1.4.0] - 2020-01-24
 
 ### Added
 - Add save-and-copy button

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,7 +20,6 @@
 -dontwarn com.google.common.**
 -dontwarn org.slf4j.**
 -keep class androidx.appcompat.widget.SearchView { *; }
--keep class org.openintents.openpgp.**
 -keepattributes SourceFile,LineNumberTable
 -dontobfuscate
 -keep class com.jcraft.jsch.**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,7 @@
 -dontwarn com.google.common.**
 -dontwarn org.slf4j.**
 -keep class androidx.appcompat.widget.SearchView { *; }
+-keep class org.openintents.openpgp.**
 -keepattributes SourceFile,LineNumberTable
 -dontobfuscate
 -keep class com.jcraft.jsch.**

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
@@ -40,11 +40,11 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.ArrayList
 import java.util.Locale
-import me.msfjarvis.openpgpktx.OpenPgpError
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import org.apache.commons.io.FileUtils
 import org.openintents.openpgp.IOpenPgpService2
+import org.openintents.openpgp.OpenPgpError
 
 class AutofillService : AccessibilityService() {
     private var serviceConnection: OpenPgpServiceConnection? = null

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -54,7 +54,6 @@ import kotlinx.android.synthetic.main.encrypt_layout.generate_password
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import me.msfjarvis.openpgpktx.OpenPgpError
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpApi.Companion.ACTION_DECRYPT_VERIFY
 import me.msfjarvis.openpgpktx.util.OpenPgpApi.Companion.RESULT_CODE
@@ -67,6 +66,7 @@ import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
 import org.openintents.openpgp.IOpenPgpService2
+import org.openintents.openpgp.OpenPgpError
 
 class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
     private val clipboard: ClipboardManager by lazy {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ ext.deps = [
         commons_codec: 'commons-codec:commons-codec:1.13',
         jsch: 'com.jcraft:jsch:0.1.55',
         jgit: 'org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r',
-        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:1.1.0',
+        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:bug~error-unmarshal-SNAPSHOT',
         ssh_auth: 'org.sufficientlysecure:sshauthentication-api:1.0'
     ],
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ ext.deps = [
         commons_codec: 'commons-codec:commons-codec:1.13',
         jsch: 'com.jcraft:jsch:0.1.55',
         jgit: 'org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r',
-        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:bug~error-unmarshal-SNAPSHOT',
+        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:1.2.0',
         ssh_auth: 'org.sufficientlysecure:sshauthentication-api:1.0'
     ],
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes #614

## :bulb: Motivation and Context
`org.openintents.openpgp.OpenPgpError` is used by OpenKeychain to unmarshal errors but our variant was in the wrong package. openpgp-ktx version [1.2.0](https://github.com/android-password-store/openpgp-ktx/releases/tag/1.2.0)


## :green_heart: How did you test it?
Manual verification

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->