### PR TITLE
Theming related fixes

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -88,7 +88,7 @@ class UserPreference : AppCompatActivity() {
             val clearClipboard20xPreference = findPreference<CheckBoxPreference>("clear_clipboard_20x")
 
             // Autofill preferences
-            autoFillEnablePreference = findPreference<CheckBoxPreference>("autofill_enable")
+            autoFillEnablePreference = findPreference("autofill_enable")
             val autoFillAppsPreference = findPreference<Preference>("autofill_apps")
             val autoFillDefaultPreference = findPreference<CheckBoxPreference>("autofill_default")
             val autoFillAlwaysShowDialogPreference = findPreference<CheckBoxPreference>("autofill_always")

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -18,6 +18,7 @@ import java.io.File
 class FolderCreationDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireContext())
+        alertDialogBuilder.setTitle(R.string.title_create_folder)
         alertDialogBuilder.setView(R.layout.folder_creation_dialog_fragment)
         alertDialogBuilder.setPositiveButton(getString(R.string.button_create)) { _: DialogInterface, _: Int ->
             createDirectory(requireArguments().getString(CURRENT_DIR_EXTRA)!!)

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -145,9 +145,12 @@ open class PasswordRepository protected constructor() {
             }
             return if (settings.getBoolean("git_external", false)) {
                 val externalRepo = settings.getString("git_external_repo", null)
-                File(requireNotNull(externalRepo))
+                if (externalRepo != null)
+                    File(externalRepo)
+                else
+                    File(context.filesDir.toString(), "/store")
             } else {
-                File(context.filesDir.toString() + "/store")
+                File(context.filesDir.toString(), "/store")
             }
         }
 

--- a/app/src/main/res/layout/folder_creation_dialog_fragment.xml
+++ b/app/src/main/res/layout/folder_creation_dialog_fragment.xml
@@ -7,18 +7,10 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/title_create_folder"
-        android:textColor="@color/color_control_normal"
-        android:textAppearance="@style/TextAppearance.AppCompat.SearchResult.Title"/>
-
     <com.google.android.material.textfield.TextInputLayout
         style="@style/TextInputLayoutBase"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:hint="@string/crypto_name_hint"
         app:hintTextColor="@color/color_control_normal"
         app:hintEnabled="true">

--- a/app/src/main/res/values-night/bools.xml
+++ b/app/src/main/res/values-night/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="light_navigation_bar">true</bool>
+    <bool name="light_navigation_bar">false</bool>
 </resources>

--- a/app/src/main/res/values-night/bools.xml
+++ b/app/src/main/res/values-night/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="light_navigation_bar">false</bool>
-</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,7 +12,8 @@
 
     <!-- Theme variables -->
     <color name="window_background">@color/primary_color</color>
-    <color name="password_icon_color">#FAFAFA</color>
     <color name="color_surface">#FF111111</color>
+    <color name="navigation_bar_color">@color/primary_color</color>
     <color name="list_multiselect_background">#66EEEEEE</color>
+    <color name="status_bar_color">@color/primary_dark_color</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -15,5 +15,5 @@
     <color name="color_surface">#FF111111</color>
     <color name="navigation_bar_color">@color/primary_color</color>
     <color name="list_multiselect_background">#66EEEEEE</color>
-    <color name="status_bar_color">@color/primary_dark_color</color>
+    <color name="status_bar_color">@color/window_background</color>
 </resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="light_navigation_bar">true</bool>
-</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,9 +14,9 @@
     <!-- Theme variables -->
     <color name="window_background">#eceff1</color>
     <color name="ic_launcher_background">#D4F1EA</color>
-    <color name="password_icon_color">#757575</color>
     <color name="color_control_normal">@color/primary_text_color</color>
     <color name="color_surface">#FFFFFF</color>
     <color name="list_multiselect_background">#668eacbb</color>
+    <color name="navigation_bar_color">@color/window_background</color>
     <color name="status_bar_color">@color/primary_dark_color</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,6 @@
     <color name="color_control_normal">@color/primary_text_color</color>
     <color name="color_surface">#FFFFFF</color>
     <color name="list_multiselect_background">#668eacbb</color>
-    <color name="navigation_bar_color">@color/window_background</color>
+    <color name="navigation_bar_color">#000000</color>
     <color name="status_bar_color">@color/primary_dark_color</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,7 +14,8 @@
         <item name="colorControlNormal">@color/color_control_normal</item>
         <item name="android:colorBackgroundFloating">@color/primary_color</item>
         <item name="android:statusBarColor">@color/status_bar_color</item>
-        <item name="android:windowLightStatusBar">@bool/light_status_bar</item>
+        <item name="android:windowLightNavigationBar">@bool/light_navigation_bar</item>
+        <item name="android:navigationBarColor">@color/navigation_bar_color</item>
         <item name="android:windowBackground">@color/window_background</item>
         <item name="actionModeStyle">@style/ActionMode</item>
         <item name="alertDialogTheme">@style/AppTheme.Dialog</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,7 +14,6 @@
         <item name="colorControlNormal">@color/color_control_normal</item>
         <item name="android:colorBackgroundFloating">@color/primary_color</item>
         <item name="android:statusBarColor">@color/status_bar_color</item>
-        <item name="android:windowLightNavigationBar">@bool/light_navigation_bar</item>
         <item name="android:navigationBarColor">@color/navigation_bar_color</item>
         <item name="android:windowBackground">@color/window_background</item>
         <item name="actionModeStyle">@style/ActionMode</item>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Make navigation bar use the same colors as the app's main UI.

## :bulb: Motivation and Context
Setting full black navigation in night mode breaks UI for entire classes of Samsung and OnePlus phones that have software coded by engineers who have never seen a hex color wheel and can't tell the difference between FFFFFF and 000000. Since showing up in China with a hex colors cheatsheet is not an option as of now, we're settling on working around this.

## :green_heart: How did you test it?
Visual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
Before: https://i.imgur.com/Iyqt6Du.png
After: https://i.imgur.com/MjOE33Z.png
