### PR TITLE
Add longpress to copy implicit username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
 ### Added
 - Copy implicit username (password filename) by long pressing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
+- Copy implicit username (password filename) by long pressing
 
 ## [1.5.0] - 2020-02-21
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -127,7 +127,7 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                 crypto_password_file.setOnLongClickListener {
                     val clip = ClipData.newPlainText("pgp_handler_result_pm", name)
                     clipboard.setPrimaryClip(clip)
-                    showSnackbar(this.resources.getString(R.string.clipboard_implicit_name_toast_text))
+                    showSnackbar(this.resources.getString(R.string.clipboard_username_toast_text))
                     true
                 }
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -124,6 +124,12 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                 setContentView(R.layout.decrypt_layout)
                 crypto_password_category_decrypt.text = relativeParentPath
                 crypto_password_file.text = name
+                crypto_password_file.setOnLongClickListener {
+                    val clip = ClipData.newPlainText("pgp_handler_result_pm", name)
+                    clipboard.setPrimaryClip(clip)
+                    showSnackbar(this.resources.getString(R.string.clipboard_implicit_name_toast_text))
+                    true
+                }
 
                 crypto_password_last_changed.text = try {
                     this.resources.getString(R.string.last_changed, lastChangedString)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,4 +285,5 @@
     <string name="pref_search_on_start_hint">Open search bar when app is launched</string>
     <string name="pref_search_from_root">Always search from root</string>
     <string name="pref_search_from_root_hint">Search from root of store regardless of currently open directory</string>
+    <string name="clipboard_implicit_name_toast_text">Implicit username copied to clipboard</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,5 +285,4 @@
     <string name="pref_search_on_start_hint">Open search bar when app is launched</string>
     <string name="pref_search_from_root">Always search from root</string>
     <string name="pref_search_from_root_hint">Search from root of store regardless of currently open directory</string>
-    <string name="clipboard_implicit_name_toast_text">Implicit username copied to clipboard</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Allow implicit username (filename of password file) to be copied by longpressing it in the password display activity.

## :bulb: Motivation and Context
See #529 


## :green_heart: How did you test it?
Android Emulator

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->

<img src="https://imgur.com/Qq9T7nh.gif" width="260">
