### PR TITLE
Show snackbar when git repo is not initialized

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -18,8 +18,8 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.git.GitActivity
 import com.zeapo.pwdstore.ui.adapters.PasswordRecyclerAdapter
 import com.zeapo.pwdstore.utils.PasswordItem
@@ -48,7 +48,7 @@ class PasswordFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var listener: OnFragmentInteractionListener
     private lateinit var settings: SharedPreferences
-    private lateinit var swipe_refresher: SwipeRefreshLayout
+    private lateinit var swipeRefresher: SwipeRefreshLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,13 +66,11 @@ class PasswordFragment : Fragment() {
         val view = inflater.inflate(R.layout.password_recycler_view, container, false)
         // use a linear layout manager
         val layoutManager = LinearLayoutManager(requireContext())
-        swipe_refresher = view.findViewById(R.id.swipe_refresher)
-        swipe_refresher.setOnRefreshListener {
-            if (!PasswordRepository.isInitialized) {
-                MaterialAlertDialogBuilder(requireContext())
-                        .setMessage(getString(R.string.creation_dialog_text))
-                        .setPositiveButton(getString(R.string.dialog_ok), null).show()
-                swipe_refresher.isRefreshing = false
+        swipeRefresher = view.findViewById(R.id.swipe_refresher)
+        swipeRefresher.setOnRefreshListener {
+            if (!PasswordRepository.isGitRepo()) {
+                Snackbar.make(view, getString(R.string.clone_git_repo), Snackbar.LENGTH_SHORT).show()
+                swipeRefresher.isRefreshing = false
             } else {
                 val intent = Intent(context, GitActivity::class.java)
                 intent.putExtra("Operation", GitActivity.REQUEST_SYNC)
@@ -145,7 +143,7 @@ class PasswordFragment : Fragment() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        swipe_refresher.isRefreshing = false
+        swipeRefresher.isRefreshing = false
     }
 
     /** clears the adapter content and sets it back to the root view  */

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -76,6 +76,15 @@ open class PasswordRepository protected constructor() {
             get() = repository != null
 
         @JvmStatic
+        fun isGitRepo(): Boolean {
+            if (repository != null) {
+                // Check if remote exists
+                return repository!!.config.getSubsections("remote").isNotEmpty() ?: false
+            }
+            return false
+        }
+
+        @JvmStatic
         @Throws(Exception::class)
         fun createRepository(localDir: File) {
             localDir.delete()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,4 +306,5 @@
     <string name="pref_search_from_root_hint">Search from root of store regardless of currently open directory</string>
     <string name="password_generator_category_title">Password Generator</string>
     <string name="tap_clear_clipboard">Tap here to clear clipboard</string>
+    <string name="clone_git_repo">Clone a git repository to sync changes</string>
 </resources>


### PR DESCRIPTION
Signed-off-by: Aditya Wasan <adityawasan55@gmail.com>

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Don't launch a new activity if the repo is not a git repo.

## :bulb: Motivation and Context
Improves basic application UX.

## :green_heart: How did you test it?
Tested by syncing both on git repo and local directory. Syncs the repo if it is cloned and shows snackbar otherwise.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code