### PR TITLE
Delete AutofillMatches when deleting files

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -499,6 +499,8 @@ class PasswordStore : AppCompatActivity() {
         MaterialAlertDialogBuilder(this)
                 .setMessage(resources.getString(R.string.delete_dialog_text, item.longName))
                 .setPositiveButton(resources.getString(R.string.dialog_yes)) { _, _ ->
+                    val filesToDelete = FileUtils.listFiles(item.file, null, true)
+                    AutofillMatcher.updateMatches(applicationContext, delete = filesToDelete)
                     item.file.deleteRecursively()
                     adapter.remove(position)
                     it.remove()
@@ -665,7 +667,7 @@ class PasswordStore : AppCompatActivity() {
                             // TODO this should show a warning to the user
                             Timber.tag(TAG).e("Something went wrong while moving.")
                         } else {
-                            AutofillMatcher.updateMatchesFor(this, sourceDestinationMap)
+                            AutofillMatcher.updateMatches(this, sourceDestinationMap)
                             commitChange(this.resources
                                     .getString(
                                             R.string.git_commit_move_text,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Delete Autofill matches when the corresponding file is deleted.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We currently do not delete Autofill matches if the corresponding files are deleted. Since matches with non-existing backing files are automatically deleted when accessed, this is not a big deal.

It is however possible that a new file is created at the exact same path without the match being accessed in between, which would result in the new file inheriting the old match. Since matches are security-relevant, this should be avoided, even though it seems to be more of a theoretical problem.


## :green_heart: How did you test it?
I deleted some folders with passwords and verified the paths of the deleted matches.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
