### PR TITLE
Make preferred directory structure for Autofill configurable

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
@@ -73,9 +73,14 @@ val AssistStructure.ViewNode.webOrigin: String?
 
 data class Credentials(val username: String?, val password: String) {
     companion object {
-        fun fromStoreEntry(file: File, entry: PasswordEntry): Credentials {
-            return if (entry.hasUsername()) Credentials(entry.username, entry.password)
-            else Credentials(file.nameWithoutExtension, entry.password)
+        fun fromStoreEntry(
+            file: File,
+            entry: PasswordEntry,
+            directoryStructure: DirectoryStructure
+        ): Credentials {
+            // Always give priority to a username stored in the encrypted extras
+            val username = entry.username ?: directoryStructure.getUsernameFor(file)
+            return Credentials(username, entry.password)
         }
     }
 }
@@ -95,7 +100,7 @@ private fun makeRemoteView(
 
 fun makeFillMatchRemoteView(context: Context, file: File, formOrigin: FormOrigin): RemoteViews {
     val title = formOrigin.getPrettyIdentifier(context, untrusted = false)
-    val summary = file.nameWithoutExtension
+    val summary = AutofillPreferences.directoryStructure(context).getUsernameFor(file)
     val iconRes = R.drawable.ic_person_black_24dp
     return makeRemoteView(context, title, summary, iconRes)
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package com.zeapo.pwdstore.autofill.oreo
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.preference.PreferenceManager
+import java.io.File
+import java.nio.file.Paths
+
+private val Context.defaultSharedPreferences: SharedPreferences
+    get() = PreferenceManager.getDefaultSharedPreferences(this)
+
+enum class DirectoryStructure(val value: String) {
+    FileBased("file"),
+    DirectoryBased("directory");
+
+    fun getUsernameFor(file: File) = when (this) {
+        FileBased -> file.nameWithoutExtension
+        DirectoryBased -> file.parentFile?.name ?: file.nameWithoutExtension
+    }
+
+    fun getIdentifierFor(file: File) = when (this) {
+        FileBased -> file.parentFile?.name
+        DirectoryBased -> file.parentFile?.parentFile?.name
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun getSaveFolderName(sanitizedIdentifier: String, username: String?) = when (this) {
+        FileBased -> sanitizedIdentifier
+        DirectoryBased -> Paths.get(sanitizedIdentifier, username ?: "username").toString()
+    }
+
+    fun getSaveFileName(username: String?) = when (this) {
+        FileBased -> username
+        DirectoryBased -> "password"
+    }
+
+    companion object {
+        const val PREFERENCE = "oreo_autofill_directory_structure"
+        private val DEFAULT = FileBased
+
+        private val reverseMap = values().associateBy { it.value }
+        fun fromValue(value: String?) = if (value != null) reverseMap[value] ?: DEFAULT else DEFAULT
+    }
+}
+
+object AutofillPreferences {
+
+    fun directoryStructure(context: Context): DirectoryStructure {
+        val value =
+            context.defaultSharedPreferences.getString(DirectoryStructure.PREFERENCE, null)
+        return DirectoryStructure.fromValue(value)
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
@@ -18,7 +18,9 @@ import com.github.ajalt.timberkt.d
 import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.PasswordEntry
 import com.zeapo.pwdstore.autofill.oreo.AutofillAction
+import com.zeapo.pwdstore.autofill.oreo.AutofillPreferences
 import com.zeapo.pwdstore.autofill.oreo.Credentials
+import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
 import com.zeapo.pwdstore.autofill.oreo.FillableForm
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -76,6 +78,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
     }
 
     private var continueAfterUserInteraction: Continuation<Intent>? = null
+    private lateinit var directoryStructure: DirectoryStructure
 
     override val coroutineContext
         get() = Dispatchers.IO + SupervisorJob()
@@ -94,6 +97,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
         }
         val isSearchAction = intent?.getBooleanExtra(EXTRA_SEARCH_ACTION, true)!!
         val action = if (isSearchAction) AutofillAction.Search else AutofillAction.Match
+        directoryStructure = AutofillPreferences.directoryStructure(this)
         d { action.toString() }
         launch {
             val credentials = decryptUsernameAndPassword(File(filePath))
@@ -176,7 +180,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
                     val entry = withContext(Dispatchers.IO) {
                         PasswordEntry(decryptedOutput)
                     }
-                    Credentials.fromStoreEntry(file, entry)
+                    Credentials.fromStoreEntry(file, entry, directoryStructure)
                 } catch (e: UnsupportedEncodingException) {
                     e(e) { "Failed to parse password entry" }
                     null

--- a/app/src/main/res/layout/encrypt_layout.xml
+++ b/app/src/main/res/layout/encrypt_layout.xml
@@ -9,13 +9,13 @@
     android:padding="@dimen/activity_horizontal_margin"
     tools:context="com.zeapo.pwdstore.crypto.PgpActivity">
 
-    <androidx.appcompat.widget.AppCompatTextView
+    <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/crypto_password_category"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:textColor="?android:attr/textColor"
-        android:textIsSelectable="false"
+        android:enabled="false"
         android:textSize="18sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -51,5 +51,13 @@
         <item>classic</item>
         <item>xkpasswd</item>
     </string-array>
+    <string-array name="oreo_autofill_directory_structure_entries">
+        <item>/example.org/john@doe.org(.gpg)</item>
+        <item>/example.org/john@doe.org/password(.gpg)</item>
+    </string-array>
+    <string-array name="oreo_autofill_directory_structure_values">
+        <item>file</item>
+        <item>directory</item>
+    </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="clipboard_username_toast_text">Username copied to clipboard</string>
     <string name="clipboard_otp_toast_text">OTP code copied to clipboard</string>
     <string name="file_toast_text">Please provide a file name</string>
+    <string name="path_toast_text">Please provide a file path</string>
     <string name="empty_toast_text">You cannot use an empty password or empty extra content</string>
 
     <!-- Git Async Task -->
@@ -268,6 +269,7 @@
     <string name="oreo_autofill_fill_support">Fill credentials</string>
     <string name="oreo_autofill_flaky_fill_support">Fill credentials (may require restarting the browser from time to time)</string>
     <string name="oreo_autofill_no_support">No support</string>
+    <string name="oreo_autofill_preference_directory_structure">Password file organization</string>
 
     <!-- Autofill -->
     <string name="autofill_description">Autofills password fields in apps. Only works for Android versions 4.3 and up. Does not rely on the clipboard for Android versions 5.0 and up.</string>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -6,6 +6,13 @@
             app:defaultValue="true"
             app:key="autofill_enable"
             app:title="@string/pref_autofill_enable_title"/>
+        <androidx.preference.ListPreference
+            app:defaultValue="file"
+            app:entries="@array/oreo_autofill_directory_structure_entries"
+            app:entryValues="@array/oreo_autofill_directory_structure_values"
+            app:key="oreo_autofill_directory_structure"
+            app:title="@string/oreo_autofill_preference_directory_structure"
+            app:useSimpleSummaryProvider="true" />
         <androidx.preference.Preference
             app:key="autofill_apps"
             app:title="@string/pref_autofill_apps_title"/>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Some users keep their password files in a directory structure such as `/example.org/john@doe.org.gpg` while others prefer the style `/example.org/john@doe.org/password.gpg`.

This commit adds a setting that allows to switch between the two. All Autofill operations, such as search, match, generate and save, respect this setting. Along the way, the suggested path for Autofill save and generate operations has now been made editable.

Note: The first style seems to be the most widely used and is therefore kept as the default. The second style is mentioned on the [official Pass website](https://www.passwordstore.org/#organization). 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #657.

## :green_heart: How did you test it?
I went through all Autofill operations in both modes. Since this is a bigger change, I would like to ask for help in testing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
![Screenshot_20200325-124049](https://user-images.githubusercontent.com/4312191/77532990-4d583e80-6e96-11ea-99c6-8f190d80fa1b.jpg)
![Screenshot_20200325-124055](https://user-images.githubusercontent.com/4312191/77532998-51845c00-6e96-11ea-92d8-f342b3c4dafc.jpg)

