### PR TITLE
Add more lenient rules that apply only on manual request

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategy.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategy.kt
@@ -88,8 +88,7 @@ val autofillStrategy = strategy {
             breakTieOnPair { any { isFocused } }
         }
         username(optional = true) {
-            takeSingle()
-            breakTieOnSingle { usernameCertainty >= Likely }
+            takeSingle { usernameCertainty >= Likely }
             breakTieOnSingle { usernameCertainty >= Certain }
             breakTieOnSingle { alreadyMatched -> directlyPrecedes(alreadyMatched) }
             breakTieOnSingle { isFocused }
@@ -104,8 +103,7 @@ val autofillStrategy = strategy {
             breakTieOnSingle { isFocused }
         }
         username(optional = true) {
-            takeSingle()
-            breakTieOnSingle { usernameCertainty >= Likely }
+            takeSingle { usernameCertainty >= Likely }
             breakTieOnSingle { usernameCertainty >= Certain }
             breakTieOnSingle { alreadyMatched -> directlyPrecedes(alreadyMatched) }
             breakTieOnSingle { isFocused }
@@ -174,6 +172,25 @@ val autofillStrategy = strategy {
             takeSingle { usernameCertainty >= Likely && isFocused }
             breakTieOnSingle { usernameCertainty >= Certain }
             breakTieOnSingle { hasAutocompleteHintUsername }
+        }
+    }
+
+    // Match any focused password field with optional username field on manual request.
+    rule(applyInSingleOriginMode = true, applyOnManualRequestOnly = true) {
+        genericPassword {
+            takeSingle { isFocused }
+        }
+        username(optional = true) {
+            takeSingle { alreadyMatched ->
+                usernameCertainty >= Likely && directlyPrecedes(alreadyMatched.singleOrNull())
+            }
+        }
+    }
+
+    // Match any focused username field on manual request.
+    rule(applyInSingleOriginMode = true, applyOnManualRequestOnly = true) {
+        username {
+            takeSingle { isFocused }
         }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
@@ -18,6 +18,7 @@ import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.BuildConfig
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.autofill.oreo.ui.AutofillSaveActivity
+import com.zeapo.pwdstore.utils.hasFlag
 
 @RequiresApi(Build.VERSION_CODES.O)
 class OreoAutofillService : AutofillService() {
@@ -62,7 +63,10 @@ class OreoAutofillService : AutofillService() {
             }
             return
         }
-        val formToFill = FillableForm.parseAssistStructure(this, structure) ?: run {
+        val formToFill = FillableForm.parseAssistStructure(
+            this, structure,
+            isManualRequest = request.flags hasFlag FillRequest.FLAG_MANUAL_REQUEST
+        ) ?: run {
             d { "Form cannot be filled" }
             callback.onSuccess(null)
             return

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -10,6 +10,10 @@ import android.util.TypedValue
 import android.view.autofill.AutofillManager
 import androidx.annotation.RequiresApi
 
+infix fun Int.hasFlag(flag: Int): Boolean {
+    return this and flag == flag
+}
+
 fun String.splitLines(): Array<String> {
     return split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add rules that match password/username fields even if no heuristic matches, but
only when the user explicitly requests Autofill. Since there is now a generic
way to always trigger Autofill (at least in apps), other rules no longer need
to match fields that fail the heuristics.

Along the way, the apply functions in AutofillStrategy.kt are renamed to match
in order to not conflict with the Kotlin apply() extension function.
Furthermore, named parameters are used more widely now to pass around Booleans.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I verified that the rules do in fact apply in manual mode.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
