### PR TITLE
Fix: Properly handle IP addresses and invalid domains in Autofill

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/PublicSuffixListCache.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/PublicSuffixListCache.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.autofill.oreo
 
 import android.content.Context
+import android.util.Patterns
 import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 
@@ -34,6 +35,16 @@ fun cachePublicSuffixList(context: Context) {
  * the return value for valid domains.
  */
 fun getPublicSuffixPlusOne(context: Context, domain: String) = runBlocking {
-    PublicSuffixListCache.getOrCachePublicSuffixList(context).getPublicSuffixPlusOne(domain)
-        .await() ?: domain
+    // We only feed valid domain names which are not IP addresses into getPublicSuffixPlusOne.
+    // We do not check whether the domain actually exists (actually, not even whether its TLD
+    // exists). As long as we restrict ourselves to syntactically valid domain names,
+    // getPublicSuffixPlusOne will return non-colliding results.
+    if (!Patterns.DOMAIN_NAME.matcher(domain).matches() || Patterns.IP_ADDRESS.matcher(domain)
+            .matches()
+    ) {
+        domain
+    } else {
+        PublicSuffixListCache.getOrCachePublicSuffixList(context).getPublicSuffixPlusOne(domain)
+            .await() ?: domain
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Mozilla's getPublicSuffixPlusOne is only meant to be invoked on syntactically
valid domain names. In particular, it does not give reasonable results for IP
addresses.

This commit ensures that the domain passed to getPublicSuffixPlusOne is
syntactically valid and not an IP address (the latter is unfortunately
considered a domain by the Android validation patterns).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I ran this against websites hosted under IP addresses.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
