### PR TITLE
Workaround: Prevent fill-in datasets from being shown on Android R

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/Form.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/Form.kt
@@ -213,7 +213,14 @@ class FillableForm private constructor(
         ): Dataset {
             val remoteView = makePlaceholderRemoteView(context)
             val scenario = AutofillScenario.fromBundle(clientState)
-            return Dataset.Builder(remoteView).run {
+            // Before Android P, Datasets used for fill-in had to come with a RemoteViews, even
+            // though they are never shown.
+            val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                Dataset.Builder()
+            } else {
+                Dataset.Builder(remoteView)
+            }
+            return builder.run {
                 if (scenario != null) fillWith(scenario, action, credentials)
                 else e { "Failed to recover scenario from client state" }
                 build()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fill-in datasets have to come with a placeholder RemoteViews before Android P, even though they are never shown. Since Android R DP2 runs into a bug with such fill-in datasets, we stop making them in Android P and later.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
2. of https://github.com/android-password-store/Android-Password-Store/pull/660#issuecomment-603894119

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
