### PR TITLE
Fix: Don't apply single-origin mode to native apps

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
@@ -141,7 +141,7 @@ private fun getBrowserSaveFlag(appPackage: String): Int? = BROWSER_SAVE_FLAG[app
 
 data class BrowserAutofillSupportInfo(
     val multiOriginMethod: BrowserMultiOriginMethod,
-    val saveFlag: Int?
+    val saveFlags: Int?
 )
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -152,7 +152,7 @@ fun getBrowserAutofillSupportInfoIfTrusted(
     if (!isTrustedBrowser(context, appPackage)) return null
     return BrowserAutofillSupportInfo(
         multiOriginMethod = getBrowserMultiOriginMethod(appPackage),
-        saveFlag = getBrowserSaveFlag(appPackage)
+        saveFlags = getBrowserSaveFlag(appPackage)
     )
 }
 
@@ -175,7 +175,7 @@ private fun getBrowserAutofillSupportLevel(
     val browserInfo = getBrowserAutofillSupportInfoIfTrusted(context, appPackage)
     return when {
         browserInfo == null -> BrowserAutofillSupportLevel.None
-        browserInfo.saveFlag != null -> BrowserAutofillSupportLevel.FillAndSave
+        browserInfo.saveFlags != null -> BrowserAutofillSupportLevel.FillAndSave
         appPackage in FLAKY_BROWSERS -> BrowserAutofillSupportLevel.FlakyFill
         else -> BrowserAutofillSupportLevel.Fill
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
An unwarranted use of the Elivs operator in Form.kt makes it such that
the restrictions of single-origin mode also apply to native apps.

This commit fixes the bug and also reduces the number of intermediate
values that can mask mistakes like this one.

It also renames saveFlag to saveFlags in BrowserAutofillSupportInfo
since this variable is not limited to contain only a single flag.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I tested filling in a native app and was offered fill options for multiple fields.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
