### PR TITLE
Fix: Commit file after Autofill generate/save

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -548,14 +548,7 @@ class PasswordStore : AppCompatActivity() {
         get() = plist?.currentDir ?: getRepositoryDirectory(applicationContext)
 
     private fun commitChange(message: String) {
-        object : GitOperation(getRepositoryDirectory(activity), activity) {
-            override fun execute() {
-                Timber.tag(TAG).d("Committing with message $message")
-                val git = Git(repository)
-                val tasks = GitAsyncTask(activity, false, true, this)
-                tasks.execute(git.add().addFilepattern("."), git.commit().setAll(true).setMessage(message))
-            }
-        }.execute()
+        Companion.commitChange(activity, message)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -771,6 +764,20 @@ class PasswordStore : AppCompatActivity() {
             val block = UnicodeBlock.of(c)
             return (!Character.isISOControl(c) &&
                     block != null && block !== UnicodeBlock.SPECIALS)
+        }
+
+        fun commitChange(activity: Activity, message: String) {
+            object : GitOperation(getRepositoryDirectory(activity), activity) {
+                override fun execute() {
+                    Timber.tag(TAG).d("Committing with message $message")
+                    val git = Git(repository)
+                    val tasks = GitAsyncTask(activity, false, true, this)
+                    tasks.execute(
+                        git.add().addFilepattern("."),
+                        git.commit().setAll(true).setMessage(message)
+                    )
+                }
+            }.execute()
         }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.os.bundleOf
 import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.PasswordStore
+import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.autofill.oreo.AutofillAction
 import com.zeapo.pwdstore.autofill.oreo.AutofillMatcher
 import com.zeapo.pwdstore.autofill.oreo.AutofillPreferences
@@ -114,12 +115,15 @@ class AutofillSaveActivity : Activity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == PasswordStore.REQUEST_CODE_ENCRYPT && resultCode == RESULT_OK && data != null) {
-            val createdPath = data.getStringExtra("CREATED_FILE")
-            if (createdPath != null) {
-                formOrigin?.let {
-                    AutofillMatcher.addMatchFor(this, it, File(createdPath))
-                }
+            val createdPath = data.getStringExtra("CREATED_FILE")!!
+            formOrigin?.let {
+                AutofillMatcher.addMatchFor(this, it, File(createdPath))
             }
+            val longName = data.getStringExtra("LONG_NAME")!!
+            // PgpActivity delegates committing the added file to PasswordStore. Since PasswordStore
+            // is not involved in an AutofillScenario, we have to commit the file ourself.
+            PasswordStore.commitChange(this, getString(R.string.git_commit_add_text, longName))
+
             val password = data.getStringExtra("PASSWORD")
             val username = data.getStringExtra("USERNAME")
             if (password != null) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Currently, password files generated via the Autofill generate or save
flow are not committed to the Git repository and therefore also not
synchronized to the remote.

The root cause is that it was missed that PgpActivity relies on
PasswordStore to commit the changes when it returns an appropriate
result code.

The fix is to extract the commit code into the companion object of
PasswordStore and call it from AutofillSaveActivity's onActivityResult.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I verified that the file is now committed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
