### PR TITLE
Fix: Restore store scroll position on back press

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -123,7 +123,7 @@ class PasswordFragment : Fragment() {
                         )
                         // push the category were we're going
                         pathStack.push(item.file)
-                        scrollPosition.push(recyclerView.verticalScrollbarPosition)
+                        scrollPosition.push((recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition())
                         recyclerView.scrollToPosition(0)
                         recyclerAdapter.clear()
                         recyclerAdapter.addAll(getPasswords(item.file, getRepositoryDirectory(context), sortOrder))
@@ -235,7 +235,7 @@ class PasswordFragment : Fragment() {
     /** Goes back one level back in the path  */
     fun popBack() {
         if (passListStack.isEmpty()) return
-        recyclerView.scrollToPosition(scrollPosition.pop())
+        (recyclerView.layoutManager as LinearLayoutManager).scrollToPosition(scrollPosition.pop())
         recyclerAdapter.clear()
         recyclerAdapter.addAll(passListStack.pop())
         pathStack.pop()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Restoring the scroll position in the main store fragment is currently
broken since the stored state (recyclerView.verticalScrollbarPosition)
is always 0 - it is just an enum that governs where the scrollbar is
placed on the screen.

The fix is to remember the list position of the last fully visible item
and scroll to it when restoring the scroll position.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
