### PR TITLE
Un-hack focus gain in folder creation dialog

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -6,11 +6,8 @@ package com.zeapo.pwdstore.ui.dialogs
 
 import android.app.Dialog
 import android.os.Bundle
-import android.os.Handler
-import android.os.SystemClock
-import android.view.MotionEvent
+import android.view.inputmethod.InputMethodManager
 import androidx.core.os.bundleOf
-import androidx.core.os.postDelayed
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
@@ -19,16 +16,6 @@ import com.zeapo.pwdstore.R
 import java.io.File
 
 class FolderCreationDialogFragment : DialogFragment() {
-
-    override fun onResume() {
-        // TODO: We really, really should not need this amount of hackery. WTF is going on?
-        super.onResume()
-        val editText = dialog?.findViewById<TextInputEditText>(R.id.folder_name_text)
-        Handler().postDelayed(300) {
-            editText?.dispatchTouchEvent(MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, 0f, 0f, 0))
-            editText?.dispatchTouchEvent(MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 0f, 0f, 0))
-        }
-    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireContext())
@@ -41,7 +28,20 @@ class FolderCreationDialogFragment : DialogFragment() {
             dismiss()
         }
         isCancelable = false
-        return alertDialogBuilder.create()
+        val dialog = alertDialogBuilder.create()
+        dialog.setOnShowListener {
+            // https://stackoverflow.com/a/13056259/297261
+            dialog.findViewById<TextInputEditText>(R.id.folder_name_text)!!.apply {
+                setOnFocusChangeListener { v, _ ->
+                    v.post {
+                        val imm = activity!!.getSystemService(InputMethodManager::class.java)
+                        imm?.showSoftInput(v, InputMethodManager.SHOW_IMPLICIT)
+                    }
+                }
+                requestFocus()
+            }
+        }
+        return dialog
     }
 
     private fun createDirectory(currentDir: String) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The current way to let the folder name EditText in the folder creation
dialog gain focus is... slightly hacky.

This commit proposes a more conceptual solution, which, if it works
reliably, could be much easier to maintain.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
