### PR TITLE
Fix: Set childCount correctly on recycled rows

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/EntryRecyclerAdapter.kt
@@ -99,10 +99,8 @@ abstract class EntryRecyclerAdapter internal constructor(val values: ArrayList<P
                 !(!showHidden && (pathname.isDirectory && pathname.isHidden))
             } ?: emptyArray<File>()
             val childCount = children.size
-            if (childCount > 0) {
-                holder.childCount.visibility = View.VISIBLE
-                holder.childCount.text = "$childCount"
-            }
+            holder.childCount.visibility = if (childCount > 0) View.VISIBLE else View.GONE
+            holder.childCount.text = "$childCount"
         } else {
             holder.typeImage.setImageResource(R.drawable.ic_action_secure_24dp)
             val parentPath = pass.fullPathToParent.replace("(^/)|(/$)".toRegex(), "")


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The childCount is not set explicitly for empty directories, which means
that the childCount of the entry from which the current row was
recycled is preserved. This results in empty directories being shown
with seemingly random child counts.

The fix is to always set text and visibility for the childCount view.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
