### PR TITLE
Workaround and potential fix for search issues

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -159,7 +159,7 @@ class PasswordStore : AppCompatActivity() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.main_menu, menu)
         searchItem = menu.findItem(R.id.action_search)
@@ -167,6 +167,7 @@ class PasswordStore : AppCompatActivity() {
         searchView.setOnQueryTextListener(
                 object : OnQueryTextListener {
                     override fun onQueryTextSubmit(s: String): Boolean {
+                        filterListAdapter(s)
                         searchView.clearFocus()
                         return true
                     }
@@ -193,7 +194,7 @@ class PasswordStore : AppCompatActivity() {
         if (settings.getBoolean("search_on_start", false)) {
             searchItem.expandActionView()
         }
-        return super.onCreateOptionsMenu(menu)
+        return super.onPrepareOptionsMenu(menu)
     }
 
     // Handle action bar item clicks here. The action bar will


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Set the event listeners on the SearchView in `onPrepareOptionsMenu` so that they are run every time the options menu is refreshed.

Also, initiate a search again when the user uses the IME search action, both to diagnose broken event listeners and provide users with a reasonable workaround if search continues to be broken on some devices.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
May resolve #426.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
