### PR TITLE
Update dependencies and fix Gradle props

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ ext.deps = [
     gradle_plugin: [
         android: 'com.android.tools.build:gradle:3.6.2',
         kotlin: 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71',
-        spotless: 'com.diffplug.spotless:spotless-plugin-gradle:3.28.0'
+        spotless: 'com.diffplug.spotless:spotless-plugin-gradle:3.28.1'
     ],
 
     kotlin: [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,7 +14,7 @@ ext.versions = [
 
 ext.deps = [
     gradle_plugin: [
-        android: 'com.android.tools.build:gradle:3.6.1',
+        android: 'com.android.tools.build:gradle:3.6.2',
         kotlin: 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71',
         spotless: 'com.diffplug.spotless:spotless-plugin-gradle:3.28.0'
     ],

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,6 @@ android.useAndroidX=true
 # R8 Full mode
 android.enableR8.fullMode=true
 
-# Reduce memory usage in CI pipeline
-org.gradle.daemon=false
-org.gradle.parallel=true
-org.gradle.caching=true
-org.gradle.configureondemand=true
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
 # Disable warnings for experimental options
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableR8.fullMode,android.namespacedRClass
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ android.useAndroidX=true
 android.enableR8.fullMode=true
 
 # Disable warnings for experimental options
-android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableR8.fullMode,android.namespacedRClass
+android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableR8.fullMode,android.useMinimalKeepRules,android.namespacedRClass
 
 # https://jakewharton.com/increased-accuracy-of-aapt2-keep-rules/
 android.useMinimalKeepRules=true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Update AGP to 3.6.2 and remove CI-specific Gradle properties

## :bulb: Motivation and Context
We configure our CI to not use the Gradle daemon as a way of faster cold starts and lesser memory
usage but we left those props in the repository's root gradle.properties which causes those
settings to also apply to development machines that do not have CI constraints.

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
