### PR TITLE
Fix: Make generated entry path editable without suggested username

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -163,7 +163,7 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                     setText(getRelativePath(fullPath, repoPath))
                     // If the activity has been provided with suggested info, we allow the user to
                     // edit the path, otherwise we style the EditText like a TextView.
-                    if (suggestedName != null) {
+                    if (suggestedName != null || suggestedPass != null) {
                         isEnabled = true
                     } else {
                         setBackgroundColor(getColor(android.R.color.transparent))


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The path of a new entry created via Autofill should always be editable, even when no username is prefilled (e.g., when generating a new password or saving a form with no detected username field).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
