### PR TITLE
Fix: Make path editable when generating a password

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -161,9 +161,10 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                 title = getString(R.string.new_password_title)
                 crypto_password_category.apply {
                     setText(getRelativePath(fullPath, repoPath))
-                    // If the activity has been provided with suggested info, we allow the user to
-                    // edit the path, otherwise we style the EditText like a TextView.
-                    if (suggestedName != null || suggestedPass != null) {
+                    // If the activity has been provided with suggested info or is meant to generate
+                    // a password, we allow the user to edit the path, otherwise we style the
+                    // EditText like a TextView.
+                    if (suggestedName != null || suggestedPass != null || shouldGeneratePassword) {
                         isEnabled = true
                     } else {
                         setBackgroundColor(getColor(android.R.color.transparent))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Make the suggested file path editable when showing the new password dialog in the context of an Autofill generate action.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should have been in #687, but of course it was missed.

## :green_heart: How did you test it?
I tapped "Generate password..." and confirmed that the path was editable.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
