### PR TITLE
Remove an erroneous check on directory moves

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -657,7 +657,6 @@ class PasswordStore : AppCompatActivity() {
                                     .show()
                         }
                         val sourceDestinationMap = if (source.isDirectory) {
-                            check(destinationFile.isDirectory) { "Moving a directory to a file" }
                             // Recursively list all files (not directories) below `source`, then
                             // obtain the corresponding target file by resolving the relative path
                             // starting at the destination folder.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Remove a check that breaks moving directories (since `isDirectory` is always `false` for a non-existing path).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving directories is currently broken.


## :green_heart: How did you test it?
Moving directories works again.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
