### PR TITLE
Switch refactored entities to ViewBinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,8 @@ android {
         }
     }
 
+    viewBinding.enabled = true
+
     defaultConfig {
         applicationId versions.packageName
     }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
+import com.zeapo.pwdstore.databinding.PasswordRecyclerViewBinding
 import com.zeapo.pwdstore.git.GitActivity
 import com.zeapo.pwdstore.ui.OnOffItemAnimator
 import com.zeapo.pwdstore.ui.adapters.PasswordItemRecyclerAdapter
@@ -39,8 +40,10 @@ class PasswordFragment : Fragment() {
 
     private var recyclerViewStateToRestore: Parcelable? = null
     private var actionMode: ActionMode? = null
+    private var _binding: PasswordRecyclerViewBinding? = null
 
     private val model: SearchableRepositoryViewModel by activityViewModels()
+    private val binding get() = _binding!!
 
     private fun requireStore() = requireActivity() as PasswordStore
 
@@ -49,28 +52,28 @@ class PasswordFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.password_recycler_view, container, false)
-        initializePasswordList(view)
-        val fab = view.findViewById<FloatingActionButton>(R.id.fab)
+        _binding = PasswordRecyclerViewBinding.inflate(inflater, container, false)
+        initializePasswordList()
+        val fab = binding.fab
         fab.setOnClickListener {
             toggleFabExpand(fab)
         }
-        view.findViewById<FloatingActionButton>(R.id.create_folder).setOnClickListener {
+        binding.createFolder.setOnClickListener {
             requireStore().createFolder()
             toggleFabExpand(fab)
         }
-        view.findViewById<FloatingActionButton>(R.id.create_password).setOnClickListener {
+        binding.createPassword.setOnClickListener {
             requireStore().createPassword()
             toggleFabExpand(fab)
         }
-        return view
+        return binding.root
     }
 
-    private fun initializePasswordList(rootView: View) {
-        swipeRefresher = rootView.findViewById(R.id.swipe_refresher)
+    private fun initializePasswordList() {
+        swipeRefresher = binding.swipeRefresher
         swipeRefresher.setOnRefreshListener {
             if (!PasswordRepository.isGitRepo()) {
-                Snackbar.make(rootView, getString(R.string.clone_git_repo), Snackbar.LENGTH_SHORT)
+                Snackbar.make(binding.root, getString(R.string.clone_git_repo), Snackbar.LENGTH_SHORT)
                     .show()
                 swipeRefresher.isRefreshing = false
             } else {
@@ -100,7 +103,7 @@ class PasswordFragment : Fragment() {
                     actionMode!!.finish()
                 }
             }
-        recyclerView = rootView.findViewById(R.id.pass_recycler)
+        recyclerView = binding.passRecycler
         recyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())
             itemAnimator = OnOffItemAnimator()
@@ -129,6 +132,11 @@ class PasswordFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
     private fun toggleFabExpand(fab: FloatingActionButton) = with(fab) {
         isExpanded = !isExpanded
         isActivated = isExpanded
@@ -142,7 +150,7 @@ class PasswordFragment : Fragment() {
             // Inflate a menu resource providing context menu items
             mode.menuInflater.inflate(R.menu.context_pass, menu)
             // hide the fab
-            requireActivity().findViewById<View>(R.id.fab).visibility = View.GONE
+            binding.fab.visibility = View.GONE
             return true
         }
 
@@ -188,7 +196,7 @@ class PasswordFragment : Fragment() {
             recyclerAdapter.requireSelectionTracker().clearSelection()
             actionMode = null
             // show the fab
-            requireActivity().findViewById<View>(R.id.fab).visibility = View.VISIBLE
+            binding.fab.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
@@ -33,8 +33,8 @@ import com.zeapo.pwdstore.autofill.oreo.AutofillMatcher
 import com.zeapo.pwdstore.autofill.oreo.AutofillPreferences
 import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
 import com.zeapo.pwdstore.autofill.oreo.FormOrigin
+import com.zeapo.pwdstore.databinding.ActivityOreoAutofillFilterBinding
 import com.zeapo.pwdstore.utils.PasswordItem
-import kotlinx.android.synthetic.main.activity_oreo_autofill_filter.*
 
 @TargetApi(Build.VERSION_CODES.O)
 class AutofillFilterView : AppCompatActivity() {
@@ -71,6 +71,7 @@ class AutofillFilterView : AppCompatActivity() {
 
     private lateinit var formOrigin: FormOrigin
     private lateinit var directoryStructure: DirectoryStructure
+    private lateinit var binding: ActivityOreoAutofillFilterBinding
 
     private val model: SearchableRepositoryViewModel by viewModels {
         ViewModelProvider.AndroidViewModelFactory(application)
@@ -78,7 +79,8 @@ class AutofillFilterView : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_oreo_autofill_filter)
+        binding = ActivityOreoAutofillFilterBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setFinishOnTouchOutside(true)
 
         val params = window.attributes
@@ -127,13 +129,13 @@ class AutofillFilterView : AppCompatActivity() {
         }.onItemClicked { _, item ->
             decryptAndFill(item)
         }
-        rvPassword.apply {
+        binding.rvPassword.apply {
             adapter = recyclerAdapter
             layoutManager = LinearLayoutManager(context)
         }
 
         val initialFilter = formOrigin.getPrettyIdentifier(applicationContext, untrusted = false)
-        search.setText(initialFilter, TextView.BufferType.EDITABLE)
+        binding.search.setText(initialFilter, TextView.BufferType.EDITABLE)
         val filterMode =
             if (formOrigin is FormOrigin.Web) FilterMode.StrictDomain else FilterMode.Fuzzy
         model.search(
@@ -142,7 +144,7 @@ class AutofillFilterView : AppCompatActivity() {
             searchMode = SearchMode.RecursivelyInSubdirectories,
             listMode = ListMode.FilesOnly
         )
-        search.addTextChangedListener {
+        binding.search.addTextChangedListener {
             model.search(
                 it.toString().trim(),
                 filterMode = FilterMode.Fuzzy,
@@ -155,21 +157,21 @@ class AutofillFilterView : AppCompatActivity() {
             recyclerAdapter.submitList(list)
             // Switch RecyclerView out for a "no results" message if the new list is empty and
             // the message is not yet shown (and vice versa).
-            if ((list.isEmpty() && rvPasswordSwitcher.nextView.id == rvPasswordEmpty.id) ||
-                (list.isNotEmpty() && rvPasswordSwitcher.nextView.id == rvPassword.id)
+            if ((list.isEmpty() && binding.rvPasswordSwitcher.nextView.id == binding.rvPasswordEmpty.id) ||
+                (list.isNotEmpty() && binding.rvPasswordSwitcher.nextView.id == binding.rvPassword.id)
             )
-                rvPasswordSwitcher.showNext()
+                binding.rvPasswordSwitcher.showNext()
         }
 
-        shouldMatch.text = getString(
+        binding.shouldMatch.text = getString(
             R.string.oreo_autofill_match_with,
             formOrigin.getPrettyIdentifier(applicationContext)
         )
     }
 
     private fun decryptAndFill(item: PasswordItem) {
-        if (shouldClear.isChecked) AutofillMatcher.clearMatchesFor(applicationContext, formOrigin)
-        if (shouldMatch.isChecked) AutofillMatcher.addMatchFor(
+        if (binding.shouldClear.isChecked) AutofillMatcher.clearMatchesFor(applicationContext, formOrigin)
+        if (binding.shouldMatch.isChecked) AutofillMatcher.addMatchFor(
             applicationContext,
             formOrigin,
             item.file

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
@@ -60,36 +60,39 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
         }
         supportActionBar?.hide()
         showPackageInfo()
-
-        binding.okButton.setOnClickListener { finish() }
-        binding.advancedButton.setOnClickListener {
-            binding.advancedButton.visibility = View.INVISIBLE
-            binding.warningAppAdvancedInfo.visibility = View.VISIBLE
-            binding.resetButton.visibility = View.VISIBLE
-        }
-        binding.resetButton.setOnClickListener {
-            AutofillMatcher.clearMatchesFor(this, FormOrigin.App(appPackage))
-            finish()
+        with(binding) {
+            okButton.setOnClickListener { finish() }
+            advancedButton.setOnClickListener {
+                advancedButton.visibility = View.INVISIBLE
+                warningAppAdvancedInfo.visibility = View.VISIBLE
+                resetButton.visibility = View.VISIBLE
+            }
+            resetButton.setOnClickListener {
+                AutofillMatcher.clearMatchesFor(this@AutofillPublisherChangedActivity, FormOrigin.App(appPackage))
+                finish()
+            }
         }
     }
 
     private fun showPackageInfo() {
         try {
-            val packageInfo =
-                packageManager.getPackageInfo(appPackage, PackageManager.GET_META_DATA)
-            val installTime = DateUtils.getRelativeTimeSpanString(packageInfo.firstInstallTime)
-            binding.warningAppInstallDate.text =
-                getString(R.string.oreo_autofill_warning_publisher_install_time, installTime)
-            val appInfo =
-                packageManager.getApplicationInfo(appPackage, PackageManager.GET_META_DATA)
-            binding.warningAppName.text = "“${packageManager.getApplicationLabel(appInfo)}”"
+            with(binding) {
+                val packageInfo =
+                        packageManager.getPackageInfo(appPackage, PackageManager.GET_META_DATA)
+                val installTime = DateUtils.getRelativeTimeSpanString(packageInfo.firstInstallTime)
+                warningAppInstallDate.text =
+                        getString(R.string.oreo_autofill_warning_publisher_install_time, installTime)
+                val appInfo =
+                        packageManager.getApplicationInfo(appPackage, PackageManager.GET_META_DATA)
+                warningAppName.text = "“${packageManager.getApplicationLabel(appInfo)}”"
 
-            val currentHash = computeCertificatesHash(this, appPackage)
-            binding.warningAppAdvancedInfo.text = getString(
-                R.string.oreo_autofill_warning_publisher_advanced_info_template,
-                appPackage,
-                currentHash
-            )
+                val currentHash = computeCertificatesHash(this@AutofillPublisherChangedActivity, appPackage)
+                warningAppAdvancedInfo.text = getString(
+                        R.string.oreo_autofill_warning_publisher_advanced_info_template,
+                        appPackage,
+                        currentHash
+                )
+            }
         } catch (exception: Exception) {
             e(exception) { "Failed to retrieve package info for $appPackage" }
             finish()

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
@@ -21,7 +21,7 @@ import com.zeapo.pwdstore.autofill.oreo.AutofillMatcher
 import com.zeapo.pwdstore.autofill.oreo.AutofillPublisherChangedException
 import com.zeapo.pwdstore.autofill.oreo.FormOrigin
 import com.zeapo.pwdstore.autofill.oreo.computeCertificatesHash
-import kotlinx.android.synthetic.main.activity_oreo_autofill_publisher_changed.*
+import com.zeapo.pwdstore.databinding.ActivityOreoAutofillPublisherChangedBinding
 
 @TargetApi(Build.VERSION_CODES.O)
 class AutofillPublisherChangedActivity : AppCompatActivity() {
@@ -45,10 +45,12 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
     }
 
     private lateinit var appPackage: String
+    private lateinit var binding: ActivityOreoAutofillPublisherChangedBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_oreo_autofill_publisher_changed)
+        binding = ActivityOreoAutofillPublisherChangedBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setFinishOnTouchOutside(true)
 
         appPackage = intent.getStringExtra(EXTRA_APP_PACKAGE) ?: run {
@@ -59,13 +61,13 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
         supportActionBar?.hide()
         showPackageInfo()
 
-        okButton.setOnClickListener { finish() }
-        advancedButton.setOnClickListener {
-            advancedButton.visibility = View.INVISIBLE
-            warningAppAdvancedInfo.visibility = View.VISIBLE
-            resetButton.visibility = View.VISIBLE
+        binding.okButton.setOnClickListener { finish() }
+        binding.advancedButton.setOnClickListener {
+            binding.advancedButton.visibility = View.INVISIBLE
+            binding.warningAppAdvancedInfo.visibility = View.VISIBLE
+            binding.resetButton.visibility = View.VISIBLE
         }
-        resetButton.setOnClickListener {
+        binding.resetButton.setOnClickListener {
             AutofillMatcher.clearMatchesFor(this, FormOrigin.App(appPackage))
             finish()
         }
@@ -76,14 +78,14 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
             val packageInfo =
                 packageManager.getPackageInfo(appPackage, PackageManager.GET_META_DATA)
             val installTime = DateUtils.getRelativeTimeSpanString(packageInfo.firstInstallTime)
-            warningAppInstallDate.text =
+            binding.warningAppInstallDate.text =
                 getString(R.string.oreo_autofill_warning_publisher_install_time, installTime)
             val appInfo =
                 packageManager.getApplicationInfo(appPackage, PackageManager.GET_META_DATA)
-            warningAppName.text = "“${packageManager.getApplicationLabel(appInfo)}”"
+            binding.warningAppName.text = "“${packageManager.getApplicationLabel(appInfo)}”"
 
             val currentHash = computeCertificatesHash(this, appPackage)
-            warningAppAdvancedInfo.text = getString(
+            binding.warningAppAdvancedInfo.text = getString(
                 R.string.oreo_autofill_warning_publisher_advanced_info_template,
                 appPackage,
                 currentHash


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Migrate all the classes that have been refactored or newly added to ViewBinding.

## :bulb: Motivation and Context
Both `kotlin-android-extensions` as well as `findViewById` have major drawbacks that are addressed by ViewBinding in a clear way.

#### `kotlin-android-extensions`
- No null-safety
- No relation to application lifecycle
- Allows you to reference views that are not even present in the current layout
- Peppers the code with underscore variable names

#### `findViewById`
- No null-safety
- No type type safety

ViewBinding solves all these limitations and moves more of the error checking into a compile time operation rather than
a runtime failure.

## :green_heart: How did you test it?
Manually verify the activities and fragments with changes continue to work as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
Refactor more cruft to allow separation of concerns (`PgpActivity` and `GitActivity` are huge offendors) and then migrate
them to ViewBinding as well. The end goal is to be able to turn off `kotlin-android-extensions` plugin entirely.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
