### PR TITLE
Request WRITE_EXTERNAL_STORAGE for external password repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Text input box theming
-- Password repository held in non-hidden storage often fails
+- Password repository held in non-hidden storage no longer fails
 
 ## [1.6.0] - 2020-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Text input box theming
+- Password repository held in non-hidden storage often fails
 
 ## [1.6.0] - 2020-03-20
 

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -107,7 +107,7 @@ class PasswordStore : AppCompatActivity() {
         var savedInstance = savedInstanceState
         if (savedInstanceState != null && (!settings.getBoolean("git_external", false) ||
                         ContextCompat.checkSelfPermission(
-                                activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+                                activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                         != PackageManager.PERMISSION_GRANTED)) {
             savedInstance = null
         }
@@ -129,9 +129,9 @@ class PasswordStore : AppCompatActivity() {
         super.onResume()
         // do not attempt to checkLocalRepository() if no storage permission: immediate crash
         if (settings.getBoolean("git_external", false)) {
-            if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+            if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     != PackageManager.PERMISSION_GRANTED) {
-                if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                     val snack = Snackbar.make(
                                     findViewById(R.id.main_layout),
                                     getString(R.string.access_sdcard_text),
@@ -139,7 +139,7 @@ class PasswordStore : AppCompatActivity() {
                             .setAction(R.string.dialog_ok) {
                                 ActivityCompat.requestPermissions(
                                         activity,
-                                        arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
+                                        arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
                                         REQUEST_EXTERNAL_STORAGE)
                             }
                     snack.show()
@@ -151,7 +151,7 @@ class PasswordStore : AppCompatActivity() {
                     // No explanation needed, we can request the permission.
                     ActivityCompat.requestPermissions(
                             activity,
-                            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
+                            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
                             REQUEST_EXTERNAL_STORAGE)
                 }
             } else {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
When the password repository is held in external storage, we need to be able to
both read and write to the directory. Before this, we only ever acquired read
permissions. This fixes it. Credits to @savar for the research into this in issue #697

## :bulb: Motivation and Context
In #365 we've seen multiple failures regarding this particular problem and I've
been able to confirm this fixes it.

## :green_heart: How did you test it?
Manually create, delete and move passwords without any crashes or log splats.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
