### PR TITLE
Fix repository corruption by AutofillSaveActivity

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -796,12 +796,12 @@ class PasswordStore : AppCompatActivity() {
                     block != null && block !== UnicodeBlock.SPECIALS)
         }
 
-        fun commitChange(activity: Activity, message: String) {
+        fun commitChange(activity: Activity, message: String, finishWithResultOnEnd: Intent? = null) {
             object : GitOperation(getRepositoryDirectory(activity), activity) {
                 override fun execute() {
                     Timber.tag(TAG).d("Committing with message $message")
                     val git = Git(repository)
-                    val tasks = GitAsyncTask(activity, false, true, this)
+                    val tasks = GitAsyncTask(activity, true, this, finishWithResultOnEnd)
                     tasks.execute(
                         git.add().addFilepattern("."),
                         git.commit().setAll(true).setMessage(message)

--- a/app/src/main/java/com/zeapo/pwdstore/git/BreakOutOfDetached.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BreakOutOfDetached.kt
@@ -58,7 +58,7 @@ class BreakOutOfDetached(fileDir: File, callingActivity: Activity) : GitOperatio
                 }
             }
         }
-        GitAsyncTask(callingActivity, false, true, this)
+        GitAsyncTask(callingActivity, true, this, null)
                 .execute(*this.commands.toTypedArray())
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.git
 
 import android.app.Activity
+import android.content.Intent
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import java.io.File
@@ -60,7 +61,7 @@ class CloneOperation(fileDir: File, callingActivity: Activity) : GitOperation(fi
 
     override fun execute() {
         (this.command as? CloneCommand)?.setCredentialsProvider(this.provider)
-        GitAsyncTask(callingActivity, true, false, this).execute(this.command)
+        GitAsyncTask(callingActivity, false, this, Intent()).execute(this.command)
     }
 
     override fun onError(errorMessage: String) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.java
@@ -6,6 +6,7 @@ package com.zeapo.pwdstore.git;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.Intent;
 import android.os.AsyncTask;
 import com.zeapo.pwdstore.PasswordStore;
 import com.zeapo.pwdstore.R;
@@ -22,20 +23,20 @@ import org.eclipse.jgit.transport.RemoteRefUpdate;
 
 public class GitAsyncTask extends AsyncTask<GitCommand, Integer, String> {
     private WeakReference<Activity> activityWeakReference;
-    private boolean finishOnEnd;
     private boolean refreshListOnEnd;
     private ProgressDialog dialog;
     private GitOperation operation;
+    private Intent finishWithResultOnEnd;
 
     public GitAsyncTask(
             Activity activity,
-            boolean finishOnEnd,
             boolean refreshListOnEnd,
-            GitOperation operation) {
+            GitOperation operation,
+            Intent finishWithResultOnEnd) {
         this.activityWeakReference = new WeakReference<>(activity);
-        this.finishOnEnd = finishOnEnd;
         this.refreshListOnEnd = refreshListOnEnd;
         this.operation = operation;
+        this.finishWithResultOnEnd = finishWithResultOnEnd;
 
         dialog = new ProgressDialog(getActivity());
     }
@@ -124,8 +125,8 @@ public class GitAsyncTask extends AsyncTask<GitCommand, Integer, String> {
         } else {
             this.operation.onSuccess();
 
-            if (finishOnEnd) {
-                this.getActivity().setResult(Activity.RESULT_OK);
+            if (finishWithResultOnEnd != null) {
+                this.getActivity().setResult(Activity.RESULT_OK, finishWithResultOnEnd);
                 this.getActivity().finish();
             }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.git
 
 import android.app.Activity
+import android.content.Intent
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import java.io.File
@@ -34,7 +35,7 @@ class PullOperation(fileDir: File, callingActivity: Activity) : GitOperation(fil
 
     override fun execute() {
         (this.command as? PullCommand)?.setCredentialsProvider(this.provider)
-        GitAsyncTask(callingActivity, true, false, this).execute(this.command)
+        GitAsyncTask(callingActivity, false, this, Intent()).execute(this.command)
     }
 
     override fun onError(errorMessage: String) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.git
 
 import android.app.Activity
+import android.content.Intent
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import java.io.File
@@ -34,7 +35,7 @@ class PushOperation(fileDir: File, callingActivity: Activity) : GitOperation(fil
 
     override fun execute() {
         (this.command as? PushCommand)?.setCredentialsProvider(this.provider)
-        GitAsyncTask(callingActivity, true, false, this).execute(this.command)
+        GitAsyncTask(callingActivity, false, this, Intent()).execute(this.command)
     }
 
     override fun onError(errorMessage: String) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.git
 
 import android.app.Activity
+import android.content.Intent
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import java.io.File
@@ -39,7 +40,7 @@ class ResetToRemoteOperation(fileDir: File, callingActivity: Activity) : GitOper
 
     override fun execute() {
         this.fetchCommand?.setCredentialsProvider(this.provider)
-        GitAsyncTask(callingActivity, true, false, this)
+        GitAsyncTask(callingActivity, false, this, Intent())
                 .execute(this.addCommand, this.fetchCommand, this.resetCommand)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
@@ -5,6 +5,7 @@
 package com.zeapo.pwdstore.git
 
 import android.app.Activity
+import android.content.Intent
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import java.io.File
@@ -48,7 +49,7 @@ class SyncOperation(fileDir: File, callingActivity: Activity) : GitOperation(fil
             this.pullCommand?.setCredentialsProvider(this.provider)
             this.pushCommand?.setCredentialsProvider(this.provider)
         }
-        GitAsyncTask(callingActivity, true, false, this).execute(this.addCommand, this.statusCommand, this.commitCommand, this.pullCommand, this.pushCommand)
+        GitAsyncTask(callingActivity, false, this, Intent()).execute(this.addCommand, this.statusCommand, this.commitCommand, this.pullCommand, this.pushCommand)
     }
 
     override fun onError(errorMessage: String) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a possible repo corruption when using Autofill's generate or save action due to a `GitAsyncTask` being cancelled in-flight when `AutofillSaveActivity` finishes.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I verified that "Running command..." is shown and the repository is intact after saving a generated password.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
