### PR TITLE
Improve search logic and UI

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -124,10 +124,18 @@ class PasswordFragment : Fragment() {
             // and not on folder navigations since the latter leads to too many removal animations.
             (recyclerView.itemAnimator as OnOffItemAnimator).isEnabled = result.isFiltered
             recyclerAdapter.submitList(result.passwordItems) {
-                recyclerViewStateToRestore?.let {
-                    recyclerView.layoutManager!!.onRestoreInstanceState(it)
+                if (result.isFiltered) {
+                    // When the result is filtered, we always scroll to the top since that is where
+                    // the best fuzzy match appears.
+                    recyclerView.scrollToPosition(0)
+                } else {
+                    // When the result is not filtered and there is a saved scroll position for it,
+                    // we try to restore it.
+                    recyclerViewStateToRestore?.let {
+                        recyclerView.layoutManager!!.onRestoreInstanceState(it)
+                    }
+                    recyclerViewStateToRestore = null
                 }
-                recyclerViewStateToRestore = null
             }
         }
     }

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -96,11 +96,11 @@ private fun PasswordItem.Companion.makeComparator(
         PasswordRepository.PasswordSortOrder.FILE_FIRST -> compareByDescending { it.type }
     }
         .then(compareBy(nullsLast(CaseInsensitiveComparator)) {
-            directoryStructure.getIdentifierFor(
-                it.file
-            )
+            directoryStructure.getIdentifierFor(it.file)
         })
-        .then(compareBy(CaseInsensitiveComparator) { directoryStructure.getUsernameFor(it.file) })
+        .then(compareBy(CaseInsensitiveComparator) {
+            directoryStructure.getUsernameFor(it.file)
+        })
 }
 
 val PasswordItem.stableId: String

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -269,6 +270,8 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
         return dir
             .walkTopDown().onEnter { file -> shouldTake(file) }
             .asFlow()
+            // Skip the root directory
+            .drop(1)
             .map {
                 yield()
                 it

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -221,7 +221,8 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
                 FilterMode.StrictDomain -> {
                     check(searchAction.listMode == ListMode.FilesOnly) { "Searches with StrictDomain search mode can only list files" }
                     prefilteredResultFlow
-                        .filter { file ->
+                        .filter { absoluteFile ->
+                            val file = absoluteFile.relativeTo(root)
                             val toMatch =
                                 directoryStructure.getIdentifierFor(file) ?: return@filter false
                             // In strict domain mode, we match

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
@@ -11,6 +11,7 @@ import android.content.Intent
 import android.content.IntentSender
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.view.autofill.AutofillManager
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -119,13 +120,26 @@ class AutofillFilterView : AppCompatActivity() {
             ::PasswordViewHolder) { item ->
             val file = item.file.relativeTo(item.rootDir)
             val pathToIdentifier = directoryStructure.getPathToIdentifierFor(file)
-            val identifier = directoryStructure.getIdentifierFor(file) ?: "INVALID"
+            val identifier = directoryStructure.getIdentifierFor(file)
             val accountPart = directoryStructure.getAccountPartFor(file)
-            title.text = buildSpannedString {
-                pathToIdentifier?.let { append("$it/") }
-                bold { underline { append(identifier) } }
+            check(identifier != null || accountPart != null) { "At least one of identifier and accountPart should always be non-null" }
+            title.text = if (identifier != null) {
+                buildSpannedString {
+                    if (pathToIdentifier != null)
+                        append("$pathToIdentifier/")
+                    bold { underline { append(identifier) } }
+                }
+            } else {
+                accountPart
             }
-            subtitle.text = accountPart
+            subtitle.apply {
+                if (identifier != null && accountPart != null) {
+                    text = accountPart
+                    visibility = View.VISIBLE
+                } else {
+                    visibility = View.GONE
+                }
+            }
         }.onItemClicked { _, item ->
             decryptAndFill(item)
         }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
@@ -154,7 +154,9 @@ class AutofillFilterView : AppCompatActivity() {
         }
         model.searchResult.observe(this) { result ->
             val list = result.passwordItems
-            recyclerAdapter.submitList(list)
+            recyclerAdapter.submitList(list) {
+                binding.rvPassword.scrollToPosition(0)
+            }
             // Switch RecyclerView out for a "no results" message if the new list is empty and
             // the message is not yet shown (and vice versa).
             if ((list.isEmpty() && binding.rvPasswordSwitcher.nextView.id == binding.rvPasswordEmpty.id) ||


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Improves search logic and UI in the following ways:

- The root directory (`store`) is no longer contained in search results.
- All RecyclerViews are scrolled to the top result (which is the best fuzzy match) when the search term is changed.
- When using the StrictDomain FilterMode, the relative path to the repository root is used for matching.
- The DirectoryStructure `get*For` functions rested on the assumption that a relative path `foo` has a parent, but it doesn't. In order to prevent future bugs, the null handling has been improved and extensively documented (including explicit types). Along the way, the UI now gracefully deals with null situations by hiding views.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #700.

## :green_heart: How did you test it?
I used search in PasswordStore and AutofillFilterActivity with both DirectoryStructures.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
I submitted these changes in one PR since they are all about search, but this should not be squash merged after the review.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
