### PR TITLE
Improve Autofill enable UI and flaky browser list

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -398,8 +398,9 @@ class UserPreference : AppCompatActivity() {
                                 val supportDescription = when (it.second) {
                                     BrowserAutofillSupportLevel.None -> getString(R.string.oreo_autofill_no_support)
                                     BrowserAutofillSupportLevel.FlakyFill -> getString(R.string.oreo_autofill_flaky_fill_support)
-                                    BrowserAutofillSupportLevel.Fill -> getString(R.string.oreo_autofill_fill_support)
-                                    BrowserAutofillSupportLevel.FillAndSave -> getString(R.string.oreo_autofill_fill_and_save_support)
+                                    BrowserAutofillSupportLevel.PasswordFill -> getString(R.string.oreo_autofill_password_fill_support)
+                                    BrowserAutofillSupportLevel.GeneralFill -> getString(R.string.oreo_autofill_general_fill_support)
+                                    BrowserAutofillSupportLevel.GeneralFillAndSave -> getString(R.string.oreo_autofill_general_fill_and_save_support)
                                 }
                                 "$appLabel: $supportDescription"
                             }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
@@ -157,14 +157,18 @@ fun getBrowserAutofillSupportInfoIfTrusted(
 }
 
 private val FLAKY_BROWSERS = listOf(
-    "com.android.chrome"
+    "com.android.chrome",
+    "com.chrome.beta",
+    "com.chrome.canary",
+    "com.chrome.dev"
 )
 
 enum class BrowserAutofillSupportLevel {
     None,
     FlakyFill,
-    Fill,
-    FillAndSave
+    PasswordFill,
+    GeneralFill,
+    GeneralFillAndSave
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -175,9 +179,10 @@ private fun getBrowserAutofillSupportLevel(
     val browserInfo = getBrowserAutofillSupportInfoIfTrusted(context, appPackage)
     return when {
         browserInfo == null -> BrowserAutofillSupportLevel.None
-        browserInfo.saveFlags != null -> BrowserAutofillSupportLevel.FillAndSave
         appPackage in FLAKY_BROWSERS -> BrowserAutofillSupportLevel.FlakyFill
-        else -> BrowserAutofillSupportLevel.Fill
+        browserInfo.multiOriginMethod == BrowserMultiOriginMethod.None -> BrowserAutofillSupportLevel.PasswordFill
+        browserInfo.saveFlags == null -> BrowserAutofillSupportLevel.GeneralFill
+        else -> BrowserAutofillSupportLevel.GeneralFillAndSave
     }
 }
 

--- a/app/src/main/res/layout/oreo_autofill_instructions.xml
+++ b/app/src/main/res/layout/oreo_autofill_instructions.xml
@@ -16,19 +16,22 @@
         <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Password Store can offer to fill login forms and even save credentials you enter in apps or on websites."
+            android:text="@string/oreo_autofill_enable_dialog_description"
             android:textSize="16sp" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="To enable this feature, tap OK to go to Autofill settings. There, select Password Store from the list."
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:text="@string/oreo_autofill_enable_dialog_instructions"
             android:textSize="16sp" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Autofill support with installed browsers:"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:text="@string/oreo_autofill_enable_dialog_installed_browsers"
+            android:textStyle="bold"
             android:textSize="16sp" />
 
         <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -254,8 +254,8 @@
     <string name="oreo_autofill_warning_publisher_warning_sign_description">Предупреждение</string>
     <string name="oreo_autofill_warning_publisher_dataset_summary">Нажмите для получения подробностей...</string>
     <string name="oreo_autofill_warning_publisher_dataset_title">Возможная попытка фишинга</string>
-    <string name="oreo_autofill_fill_and_save_support">Заполнить и сохранить учетные данные</string>
-    <string name="oreo_autofill_fill_support">Заполнить учетные данные</string>
+    <string name="oreo_autofill_general_fill_and_save_support">Заполнить и сохранить учетные данные</string>
+    <string name="oreo_autofill_general_fill_support">Заполнить учетные данные</string>
     <string name="oreo_autofill_flaky_fill_support">Заполнить учетные данные (время от времени может требоваться перезапуск браузера)</string>
     <string name="oreo_autofill_no_support">Не поддерживается</string>
     <string name="oreo_autofill_preference_directory_structure">Организация файла паролей</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,11 +271,15 @@
     <string name="oreo_autofill_warning_publisher_warning_sign_description">Warning</string>
     <string name="oreo_autofill_warning_publisher_dataset_summary">Tap for details…</string>
     <string name="oreo_autofill_warning_publisher_dataset_title">Possible phishing attempt</string>
-    <string name="oreo_autofill_fill_and_save_support">Fill and save credentials</string>
-    <string name="oreo_autofill_fill_support">Fill credentials</string>
-    <string name="oreo_autofill_flaky_fill_support">Fill credentials (may require restarting the browser from time to time)</string>
+    <string name="oreo_autofill_general_fill_and_save_support">Fill and save credentials</string>
+    <string name="oreo_autofill_general_fill_support">Fill credentials</string>
+    <string name="oreo_autofill_password_fill_support">Fill passwords</string>
+    <string name="oreo_autofill_flaky_fill_support">Fill passwords (may require restarting the browser from time to time)</string>
     <string name="oreo_autofill_no_support">No support</string>
     <string name="oreo_autofill_preference_directory_structure">Password file organization</string>
+    <string name="oreo_autofill_enable_dialog_description">Password Store can offer to fill login forms and even save credentials you enter in apps or on websites.</string>
+    <string name="oreo_autofill_enable_dialog_instructions">To enable this feature, tap OK to go to Autofill settings. There, select Password Store from the list and confirm the confirmation prompt with OK.</string>
+    <string name="oreo_autofill_enable_dialog_installed_browsers">Autofill support with installed browsers:</string>
 
     <!-- Autofill -->
     <string name="autofill_description">Autofills password fields in apps. Only works for Android versions 4.3 and up. Does not rely on the clipboard for Android versions 5.0 and up.</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Improves the Autofill enable UI in the following ways:

- Minor layout tweaks
- New support level making explicit that only password (fields) can be filled
- All Chrome versions are now on the list of potentially flaky browsers

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps

- [ ] Update the Russian translation
- [ ] @msfjarvis Autofill onboarding UI

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
