### PR TITLE
Improve Autofill search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ dependencies {
 
     // Testing-only dependencies
     androidTestImplementation deps.testing.junit
+    androidTestImplementation deps.testing.kotlin_test_junit
     androidTestImplementation deps.testing.androidx.runner
     androidTestImplementation deps.testing.androidx.rules
     androidTestImplementation deps.testing.androidx.junit

--- a/app/src/androidTest/java/com/zeapo/pwdstore/DecryptTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/DecryptTest.kt
@@ -8,6 +8,8 @@ import android.annotation.SuppressLint
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -31,6 +33,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.openintents.openpgp.IOpenPgpService2
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -109,7 +112,19 @@ class DecryptTest {
         // second set the new timer
         activity.settings.edit().putString("general_show_time", "2").commit()
 
-        activity.onBound(null)
+        activity.onBound(object : IOpenPgpService2 {
+            override fun createOutputPipe(p0: Int): ParcelFileDescriptor {
+                TODO("Not yet implemented")
+            }
+
+            override fun asBinder(): IBinder {
+                TODO("Not yet implemented")
+            }
+
+            override fun execute(p0: Intent?, p1: ParcelFileDescriptor?, p2: Int): Intent {
+                TODO("Not yet implemented")
+            }
+        })
 
         // have we decrypted things correctly?
         assertEquals(passEntry.password, activity.crypto_password_show.text)
@@ -118,14 +133,14 @@ class DecryptTest {
 
         // did we copy the password?
         val clipboard: ClipboardManager = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        assertEquals(passEntry.password, clipboard.primaryClip.getItemAt(0).text)
+        assertEquals(passEntry.password, clipboard.primaryClip!!.getItemAt(0).text)
 
         // wait until the clipboard is cleared
         SystemClock.sleep(4000)
 
         // The clipboard should be cleared!!
-        for (i in 0..clipboard.primaryClip.itemCount) {
-            assertEquals("", clipboard.primaryClip.getItemAt(i).text)
+        for (i in 0..clipboard.primaryClip!!.itemCount) {
+            assertEquals("", clipboard.primaryClip!!.getItemAt(i).text)
         }
 
         // set back the timer
@@ -145,7 +160,7 @@ class DecryptTest {
                 val destPath = "$destination/$filename"
                 val sourcePath = "$source/$filename"
 
-                if (assetManager.list(sourcePath).isNotEmpty()) {
+                if (assetManager.list(sourcePath)!!.isNotEmpty()) {
                     FileUtils.forceMkdir(File(destination, filename))
                     copyAssets("$source/$filename", destPath)
                 } else {

--- a/app/src/androidTest/java/com/zeapo/pwdstore/EncryptTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/EncryptTest.kt
@@ -7,6 +7,8 @@ package com.zeapo.pwdstore
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
@@ -25,6 +27,7 @@ import org.apache.commons.io.IOUtils
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.openintents.openpgp.IOpenPgpService2
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -67,7 +70,19 @@ class EncryptTest {
         init()
 
         onView(withId(R.id.crypto_password_category)).check(ViewAssertions.matches(withText(parentPath)))
-        activity.onBound(null)
+        activity.onBound(object : IOpenPgpService2 {
+            override fun createOutputPipe(p0: Int): ParcelFileDescriptor {
+                TODO("Not yet implemented")
+            }
+
+            override fun asBinder(): IBinder {
+                TODO("Not yet implemented")
+            }
+
+            override fun execute(p0: Intent?, p1: ParcelFileDescriptor?, p2: Int): Intent {
+                TODO("Not yet implemented")
+            }
+        })
         val clearPass = IOUtils.toString(testContext.assets.open("clear-store/category/sub"), Charsets.UTF_8.name())
         val passEntry = PasswordEntry(clearPass)
 

--- a/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
@@ -7,42 +7,42 @@ package com.zeapo.pwdstore
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import org.junit.Test as test
+import org.junit.Test
 
 private infix fun String.matchedForDomain(domain: String) =
     SearchableRepositoryViewModel.generateStrictDomainRegex(domain)?.containsMatchIn(this) == true
 
 class StrictDomainRegexTest {
-    @test fun acceptsLiteralDomain() {
+    @Test fun acceptsLiteralDomain() {
         assertTrue("work/example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertTrue("example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertTrue("example.org.gpg" matchedForDomain "example.org")
     }
 
-    @test fun acceptsSubdomains() {
+    @Test fun acceptsSubdomains() {
         assertTrue("work/www.example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertTrue("www2.example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertTrue("www.login.example.org.gpg" matchedForDomain "example.org")
     }
 
-    @test fun rejectsPhishingAttempts() {
+    @Test fun rejectsPhishingAttempts() {
         assertFalse("example.org.gpg" matchedForDomain "xample.org")
         assertFalse("login.example.org.gpg" matchedForDomain "xample.org")
         assertFalse("example.org/john.doe@exmple.org.gpg" matchedForDomain "xample.org")
         assertFalse("example.org.gpg" matchedForDomain "e/xample.org")
     }
 
-    @test fun rejectNonGpgComponentMatches() {
+    @Test fun rejectNonGpgComponentMatches() {
         assertFalse("work/example.org" matchedForDomain "example.org")
     }
 
-    @test fun rejectsEmailAddresses() {
+    @Test fun rejectsEmailAddresses() {
         assertFalse("work/notexample.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertFalse("work/notexample.org/john.doe@www.example.org.gpg" matchedForDomain "example.org")
         assertFalse("work/john.doe@www.example.org/foo.org" matchedForDomain "example.org")
     }
 
-    @test fun rejectsPathSeparators() {
+    @Test fun rejectsPathSeparators() {
         assertNull(SearchableRepositoryViewModel.generateStrictDomainRegex("ex/ample.org"))
     }
 }

--- a/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package com.zeapo.pwdstore
+
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test as test
+
+private infix fun String.matchedForDomain(domain: String) =
+    SearchableRepositoryViewModel.generateStrictDomainRegex(domain)?.containsMatchIn(this) == true
+
+class StrictDomainRegexTest {
+    @test fun acceptsLiteralDomain() {
+        assertTrue("work/example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
+        assertTrue("example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
+        assertTrue("example.org.gpg" matchedForDomain "example.org")
+    }
+
+    @test fun acceptsSubdomains() {
+        assertTrue("work/www.example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
+        assertTrue("www2.example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
+        assertTrue("www.login.example.org.gpg" matchedForDomain "example.org")
+    }
+
+    @test fun rejectsPhishingAttempts() {
+        assertFalse("example.org.gpg" matchedForDomain "xample.org")
+        assertFalse("login.example.org.gpg" matchedForDomain "xample.org")
+        assertFalse("example.org/john.doe@exmple.org.gpg" matchedForDomain "xample.org")
+        assertFalse("example.org.gpg" matchedForDomain "e/xample.org")
+    }
+
+    @test fun rejectNonGpgComponentMatches() {
+        assertFalse("work/example.org" matchedForDomain "example.org")
+    }
+
+    @test fun rejectsEmailAddresses() {
+        assertFalse("work/notexample.org/john.doe@example.org.gpg" matchedForDomain "example.org")
+        assertFalse("work/notexample.org/john.doe@www.example.org.gpg" matchedForDomain "example.org")
+        assertFalse("work/john.doe@www.example.org/foo.org" matchedForDomain "example.org")
+    }
+
+    @test fun rejectsPathSeparators() {
+        assertNull(SearchableRepositoryViewModel.generateStrictDomainRegex("ex/ample.org"))
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -97,7 +97,7 @@ private fun PasswordItem.Companion.makeComparator(
         .then(compareBy(nullsLast(CaseInsensitiveComparator)) {
             directoryStructure.getIdentifierFor(it.file)
         })
-        .then(compareBy(CaseInsensitiveComparator) {
+        .then(compareBy(nullsLast(CaseInsensitiveComparator)) {
             directoryStructure.getUsernameFor(it.file)
         })
 }

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -126,28 +126,6 @@ enum class ListMode {
 @FlowPreview
 class SearchableRepositoryViewModel(application: Application) : AndroidViewModel(application) {
 
-    companion object {
-
-        fun generateStrictDomainRegex(domain: String): Regex? {
-            // Valid domains do not contain path separators.
-            if (domain.contains('/'))
-                return null
-            // Matches the start of a path component, which is either the start of the
-            // string or a path separator.
-            val prefix = """(?:^|/)"""
-            val escapedFilter = Regex.escape(domain.replace("/", ""))
-            // Matches either the filter literally or a strict subdomain of the filter term.
-            // We allow a lot of freedom in what a subdomain is, as long as it is not an
-            // email address.
-            val subdomain = """(?:(?:[^/@]+\.)?$escapedFilter)"""
-            // Matches the end of a path component, which is either the literal ".gpg" or a
-            // path separator.
-            val suffix = """(?:\.gpg|/)"""
-            // Match any relative path with a component that is a subdomain of the filter.
-            return Regex(prefix + subdomain + suffix)
-        }
-    }
-
     private var _updateCounter = 0
     private val updateCounter: Int
         get() = _updateCounter
@@ -370,6 +348,28 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
     fun forceRefresh() {
         forceUpdateOnNextSearchAction()
         searchAction.postValue(updateSearchAction(searchAction.value!!))
+    }
+
+    companion object {
+
+        fun generateStrictDomainRegex(domain: String): Regex? {
+            // Valid domains do not contain path separators.
+            if (domain.contains('/'))
+                return null
+            // Matches the start of a path component, which is either the start of the
+            // string or a path separator.
+            val prefix = """(?:^|/)"""
+            val escapedFilter = Regex.escape(domain.replace("/", ""))
+            // Matches either the filter literally or a strict subdomain of the filter term.
+            // We allow a lot of freedom in what a subdomain is, as long as it is not an
+            // email address.
+            val subdomain = """(?:(?:[^/@]+\.)?$escapedFilter)"""
+            // Matches the end of a path component, which is either the literal ".gpg" or a
+            // path separator.
+            val suffix = """(?:\.gpg|/)"""
+            // Match any relative path with a component that is a subdomain of the filter.
+            return Regex(prefix + subdomain + suffix)
+        }
     }
 }
 

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -126,6 +126,28 @@ enum class ListMode {
 @FlowPreview
 class SearchableRepositoryViewModel(application: Application) : AndroidViewModel(application) {
 
+    companion object {
+
+        fun generateStrictDomainRegex(domain: String): Regex? {
+            // Valid domains do not contain path separators.
+            if (domain.contains('/'))
+                return null
+            // Matches the start of a path component, which is either the start of the
+            // string or a path separator.
+            val prefix = """(?:^|/)"""
+            val escapedFilter = Regex.escape(domain.replace("/", ""))
+            // Matches either the filter literally or a strict subdomain of the filter term.
+            // We allow a lot of freedom in what a subdomain is, as long as it is not an
+            // email address.
+            val subdomain = """(?:(?:[^/@]+\.)?$escapedFilter)"""
+            // Matches the end of a path component, which is either the literal ".gpg" or a
+            // path separator.
+            val suffix = """(?:\.gpg|/)"""
+            // Match any relative path with a component that is a subdomain of the filter.
+            return Regex(prefix + subdomain + suffix)
+        }
+    }
+
     private var _updateCounter = 0
     private val updateCounter: Int
         get() = _updateCounter
@@ -219,22 +241,18 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
                 }
                 FilterMode.StrictDomain -> {
                     check(searchAction.listMode == ListMode.FilesOnly) { "Searches with StrictDomain search mode can only list files" }
-                    prefilteredResultFlow
-                        .filter { absoluteFile ->
-                            val file = absoluteFile.relativeTo(root)
-                            val toMatch =
-                                directoryStructure.getIdentifierFor(file) ?: return@filter false
-                            // In strict domain mode, we match
-                            // * the search term exactly,
-                            // * subdomains of the search term,
-                            // * or the search term plus an arbitrary protocol.
-                            toMatch == searchAction.filter ||
-                                toMatch.endsWith(".${searchAction.filter}") ||
-                                toMatch.endsWith("://${searchAction.filter}")
-                        }
-                        .map { it.toPasswordItem(root) }
-                        .toList()
-                        .sortedWith(itemComparator)
+                    val regex = generateStrictDomainRegex(searchAction.filter)
+                    if (regex != null) {
+                        prefilteredResultFlow
+                            .filter { absoluteFile ->
+                                regex.containsMatchIn(absoluteFile.relativeTo(root).path)
+                            }
+                            .map { it.toPasswordItem(root) }
+                            .toList()
+                            .sortedWith(itemComparator)
+                    } else {
+                        emptyList()
+                    }
                 }
                 FilterMode.Fuzzy -> {
                     prefilteredResultFlow

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
@@ -19,6 +19,7 @@ import com.github.ajalt.timberkt.Timber.tag
 import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.PasswordEntry
 import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.utils.PasswordRepository
 import java.io.File
 import java.security.MessageDigest
 
@@ -100,7 +101,10 @@ private fun makeRemoteView(
 
 fun makeFillMatchRemoteView(context: Context, file: File, formOrigin: FormOrigin): RemoteViews {
     val title = formOrigin.getPrettyIdentifier(context, untrusted = false)
-    val summary = AutofillPreferences.directoryStructure(context).getUsernameFor(file)
+    val directoryStructure = AutofillPreferences.directoryStructure(context)
+    val relativeFile = file.relativeTo(PasswordRepository.getRepositoryDirectory(context))
+    val summary = directoryStructure.getUsernameFor(relativeFile)
+        ?: directoryStructure.getPathToIdentifierFor(relativeFile) ?: ""
     val iconRes = R.drawable.ic_person_black_24dp
     return makeRemoteView(context, title, summary, iconRes)
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
@@ -16,6 +16,7 @@ private val Context.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(this)
 
 enum class DirectoryStructure(val value: String) {
+    EncryptedUsername("encrypted_username"),
     FileBased("file"),
     DirectoryBased("directory");
 
@@ -24,11 +25,13 @@ enum class DirectoryStructure(val value: String) {
      * [DirectoryStructure].
      *
      * Examples:
+     *   - * --> null (EncryptedUsername)
      *   - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
      *   - work/example.org/john@doe.org/password.gpg --> john@doe.org (DirectoryBased)
      *   - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
      */
-    fun getUsernameFor(file: File): String = when (this) {
+    fun getUsernameFor(file: File): String? = when (this) {
+        EncryptedUsername -> null
         FileBased -> file.nameWithoutExtension
         DirectoryBased -> file.parentFile?.name ?: file.nameWithoutExtension
     }
@@ -41,12 +44,14 @@ enum class DirectoryStructure(val value: String) {
      * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
      *
      * Examples:
+     *   - work/example.org.gpg --> example.org (EncryptedUsername)
      *   - work/example.org/john@doe.org.gpg --> example.org (FileBased)
      *   - example.org.gpg --> example.org (FileBased, fallback)
      *   - work/example.org/john@doe.org/password.gpg --> example.org (DirectoryBased)
      *   - Temporary PIN.gpg --> null (DirectoryBased)
      */
     fun getIdentifierFor(file: File): String? = when (this) {
+        EncryptedUsername -> file.nameWithoutExtension
         FileBased -> file.parentFile?.name ?: file.nameWithoutExtension
         DirectoryBased -> file.parentFile?.parent
     }
@@ -55,10 +60,8 @@ enum class DirectoryStructure(val value: String) {
      * Returns the path components of [file] until right before the component that contains the
      * origin identifier according to the current [DirectoryStructure].
      *
-     * At least one of [DirectoryStructure.getIdentifierFor] and
-     * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
-     *
      * Examples:
+     *   - work/example.org.gpg --> work (EncryptedUsername)
      *   - work/example.org/john@doe.org.gpg --> work (FileBased)
      *   - example.org/john@doe.org.gpg --> null (FileBased)
      *   - john@doe.org.gpg --> null (FileBased)
@@ -66,6 +69,7 @@ enum class DirectoryStructure(val value: String) {
      *   - example.org/john@doe.org/password.gpg --> null (DirectoryBased)
      */
     fun getPathToIdentifierFor(file: File): String? = when (this) {
+        EncryptedUsername -> file.parent
         FileBased -> file.parentFile?.parent
         DirectoryBased -> file.parentFile?.parentFile?.parent
     }
@@ -74,13 +78,18 @@ enum class DirectoryStructure(val value: String) {
      * Returns the path component of [file] following the origin identifier according to the current
      * [DirectoryStructure] (without file extension).
      *
+     * At least one of [DirectoryStructure.getIdentifierFor] and
+     * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
+     *
      * Examples:
+     *   - * --> null (EncryptedUsername)
      *   - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
      *   - example.org.gpg --> null (FileBased, fallback)
      *   - work/example.org/john@doe.org/password.gpg --> john@doe.org/password (DirectoryBased)
      *   - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
      */
     fun getAccountPartFor(file: File): String? = when (this) {
+        EncryptedUsername -> null
         FileBased -> file.nameWithoutExtension.takeIf { file.parentFile != null }
         DirectoryBased -> file.parentFile?.let { parentFile ->
             "${parentFile.name}/${file.nameWithoutExtension}"
@@ -89,11 +98,13 @@ enum class DirectoryStructure(val value: String) {
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun getSaveFolderName(sanitizedIdentifier: String, username: String?) = when (this) {
+        EncryptedUsername -> "/"
         FileBased -> sanitizedIdentifier
         DirectoryBased -> Paths.get(sanitizedIdentifier, username ?: "username").toString()
     }
 
-    fun getSaveFileName(username: String?) = when (this) {
+    fun getSaveFileName(username: String?, identifier: String) = when (this) {
+        EncryptedUsername -> identifier
         FileBased -> username
         DirectoryBased -> "password"
     }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
@@ -60,7 +60,7 @@ class AutofillSaveActivity : Activity() {
                 sanitizedIdentifier = sanitizedIdentifier,
                 username = credentials?.username
             )
-            val fileName = directoryStructure.getSaveFileName(username = credentials?.username)
+            val fileName = directoryStructure.getSaveFileName(username = credentials?.username, identifier = identifier)
             val intent = Intent(context, AutofillSaveActivity::class.java).apply {
                 putExtras(
                     bundleOf(

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -609,10 +609,9 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                                         AutofillPreferences.directoryStructure(applicationContext)
                                     val entry = PasswordEntry(content)
                                     returnIntent.putExtra("PASSWORD", entry.password)
-                                    returnIntent.putExtra(
-                                        "USERNAME",
-                                        directoryStructure.getUsernameFor(file)
-                                    )
+                                    val username = PasswordEntry(content).username
+                                        ?: directoryStructure.getUsernameFor(file)
+                                    returnIntent.putExtra("USERNAME", username)
                                 }
 
                                 setResult(RESULT_OK, returnIntent)

--- a/app/src/main/res/layout/activity_oreo_autofill_filter.xml
+++ b/app/src/main/res/layout/activity_oreo_autofill_filter.xml
@@ -46,7 +46,7 @@
         android:id="@+id/rvPasswordSwitcher"
         android:layout_width="0dp"
         android:layout_marginTop="@dimen/activity_vertical_margin"
-        app:layout_constraintBottom_toTopOf="@id/shouldMatch"
+        app:layout_constraintBottom_toTopOf="@id/strictDomainSearch"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchLayout"
@@ -72,6 +72,21 @@
     </ViewSwitcher>
 
     <Switch
+        android:id="@+id/strictDomainSearch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/oreo_autofill_strict_domain_search"
+        app:layout_constraintBottom_toTopOf="@id/shouldMatch"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/rvPasswordSwitcher"
+        app:layout_constraintVertical_bias="1.0"
+        tools:text="Phishing-resistant search"/>
+
+    <Switch
         android:id="@+id/shouldMatch"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -82,7 +97,7 @@
         app:layout_constraintBottom_toTopOf="@id/shouldClear"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/rvPasswordSwitcher"
+        app:layout_constraintTop_toBottomOf="@id/strictDomainSearch"
         app:layout_constraintVertical_bias="1.0"
         tools:text="Match with example.org" />
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -52,10 +52,12 @@
         <item>xkpasswd</item>
     </string-array>
     <string-array name="oreo_autofill_directory_structure_entries">
-        <item>/example.org/john@doe.org(.gpg)</item>
-        <item>/example.org/john@doe.org/password(.gpg)</item>
+        <item>work/example.org(.gpg)</item>
+        <item>work/example.org/john@doe.org(.gpg)</item>
+        <item>work/example.org/john@doe.org/password(.gpg)</item>
     </string-array>
     <string-array name="oreo_autofill_directory_structure_values">
+        <item>encrypted_username</item>
         <item>file</item>
         <item>directory</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,7 @@
     <string name="folder_icon_hint">Folder icon</string>
 
     <!-- Oreo Autofill -->
+    <string name="oreo_autofill_strict_domain_search">Phishing-resistant search</string>
     <string name="oreo_autofill_match_with">Match with %1$s</string>
     <string name="oreo_autofill_matches_clear_existing">Clear existing matches</string>
     <string name="oreo_autofill_filter_no_results">No results.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ subprojects {
             targetSdkVersion versions.targetSdk
             versionCode versions.versionCode
             versionName versions.versionName
+
+            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         }
         compileOptions {
             sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -67,6 +67,7 @@ ext.deps = [
 
     testing: [
         junit: 'junit:junit:4.13',
+        kotlin_test_junit: 'org.jetbrains.kotlin:kotlin-test-junit:1.3.71',
         androidx: [
             runner: 'androidx.test:runner:1.3.0-alpha05',
             rules: 'androidx.test:rules:1.3.0-alpha05',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
These commits aim to make Autofill search more intuitive while preserving its phishing protection. This is done in the following ways:

- In StrictDomain (aka "Phishing-resistant search") mode, we previously only matched a particular path component, governed by the folder structure selected in the settings, against a subdomain of the search term. But users have wildly different directory layouts that we should do our best to support and we should not expect them to tweak settings to get search working. Consequently, StrictDomain now matches any path component against a subdomain of the search term, regardless of the folder structure selected in settings. The origin identifier with respect to this setting is still shown in bold underline.
- In preparation for the next point, and also because it is generally useful, an encrypted username entered for an Autofill generated password is now filled in.
- Support for a folder layout à la "work/Banking/example.org.gpg", which relies on encrypted usernames, is implemented and the ensuing increase in nullability is addressed in the UI and AutofillHelper.
- A switch is added to the Autofill search view which allows switching between Fuzzy and StrictDomain matching for websites.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #705.

## :green_heart: How did you test it?
I tried out the various features that interact with the changed code. @jvanbruegge It would be great if you could also give this a try.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps

- [ ] Decide whether the path to the file is useful for distinguishing existing Autofill matches with the new folder layout setting.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
