### PR TITLE
See file's metadata to validate SSH key

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -629,12 +629,18 @@ class UserPreference : AppCompatActivity() {
                             is IOException,
                             is IllegalArgumentException -> {
                                 MaterialAlertDialogBuilder(this)
-                                        .setTitle(this.resources.getString(R.string.ssh_key_error_dialog_title))
-                                        .setMessage(this.resources.getString(R.string.ssh_key_error_dialog_text) + e.message)
-                                        .setPositiveButton(this.resources.getString(R.string.dialog_ok), null)
+                                        .setTitle(resources.getString(R.string.ssh_key_error_dialog_title))
+                                        .setMessage(getString(R.string.ssh_key_import_error_not_an_ssh_key_message))
+                                        .setPositiveButton(resources.getString(R.string.dialog_ok), null)
                                         .show()
                             }
-                            else -> throw e
+                            else -> {
+                                MaterialAlertDialogBuilder(this)
+                                        .setTitle(resources.getString(R.string.ssh_key_error_dialog_title))
+                                        .setMessage(resources.getString(R.string.ssh_key_error_dialog_text) + e.message)
+                                        .setPositiveButton(resources.getString(R.string.dialog_ok), null)
+                                        .show()
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -523,9 +523,7 @@ class UserPreference : AppCompatActivity() {
     @Throws(IllegalArgumentException::class, IOException::class)
     private fun copySshKey(uri: Uri) {
         // See metadata from document to validate SSH key
-        contentResolver.query(
-                uri, null, null, null, null, null
-        )?.use { cursor ->
+        contentResolver.query(uri, null, null, null, null, null)?.use { cursor ->
             val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
 
             // cursor returns only 1 row
@@ -534,10 +532,9 @@ class UserPreference : AppCompatActivity() {
             val sizeFile = cursor.getInt(sizeIndex)
 
             // SSH key size < than 100KB and different from 0
-            if (sizeFile > 100000 ||
-                    sizeFile == 0)
+            if (sizeFile > 100000 || sizeFile == 0) {
                 throw IllegalArgumentException("Wrong file type selected")
-            else {
+            } else {
                 // Validate BEGIN and END markers
                 val lines = contentResolver.openInputStream(uri)?.bufferedReader()?.readLines()
 
@@ -546,8 +543,8 @@ class UserPreference : AppCompatActivity() {
                 // last line contains END
                 if (lines != null &&
                     lines.size > 2 &&
-                    !lines[0].contains("BEGIN") &&
-                    !lines[lines.size - 1].contains("END")) {
+                    !lines[0].contains("BEGIN OPENSSH PRIVATE KEY") &&
+                    !lines[lines.size - 1].contains("END OPENSSH PRIVATE KEY")) {
                     throw IllegalArgumentException("Wrong file type selected")
                 }
             }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -521,21 +521,21 @@ class UserPreference : AppCompatActivity() {
 
     @Throws(IOException::class)
     private fun copySshKey(uri: Uri) {
-        //See metadata from document to validate SSH key
-        //cursor returns only 1 row
+        // See metadata from document to validate SSH key
+        // cursor returns only 1 row
         val cursor: Cursor? = contentResolver.query(
                 uri, null, null, null, null, null)
 
         cursor?.use {
 
             if (it.moveToFirst()) {
-                //see file's metadata
+                // see file's metadata
                 val sizeIndex: Int = it.getColumnIndex(OpenableColumns.SIZE)
-                val sizeFile : Int = it.getInt(sizeIndex)
+                val sizeFile: Int = it.getInt(sizeIndex)
                 val extensionFile = File(uri.path.toString()).extension
 
-                if (extensionFile.isNotEmpty()  //SSH key without file extension
-                        || sizeFile > 100000 ) //size < than 100KB
+                if (extensionFile.isNotEmpty() || // SSH key without file extension
+                        sizeFile > 100000) // size < than 100KB
                     throw IOException("Wrong file type selected")
             }
         }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -615,12 +615,18 @@ class UserPreference : AppCompatActivity() {
                         setResult(Activity.RESULT_OK)
 
                         finish()
-                    } catch (e: IOException) {
-                        MaterialAlertDialogBuilder(this)
-                                .setTitle(this.resources.getString(R.string.ssh_key_error_dialog_title))
-                                .setMessage(this.resources.getString(R.string.ssh_key_error_dialog_text) + e.message)
-                                .setPositiveButton(this.resources.getString(R.string.dialog_ok), null)
-                                .show()
+                    } catch (e: Exception) {
+                        when (e) {
+                            is IOException,
+                            is IllegalArgumentException -> {
+                                MaterialAlertDialogBuilder(this)
+                                        .setTitle(this.resources.getString(R.string.ssh_key_error_dialog_title))
+                                        .setMessage(this.resources.getString(R.string.ssh_key_error_dialog_text) + e.message)
+                                        .setPositiveButton(this.resources.getString(R.string.dialog_ok), null)
+                                        .show()
+                            }
+                            else -> throw e
+                        }
                     }
                 }
                 EDIT_GIT_INFO -> {

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -525,21 +525,18 @@ class UserPreference : AppCompatActivity() {
         // See metadata from document to validate SSH key
         contentResolver.query(uri, null, null, null, null, null)?.use { cursor ->
             val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-
             // cursor returns only 1 row
             cursor.moveToFirst()
             // see file's metadata
-            val sizeFile = cursor.getInt(sizeIndex)
-            // SSH key size < than 100KB and different from 0
-            if (sizeFile > 100000 || sizeFile == 0) {
+            val fileSize = cursor.getInt(sizeIndex)
+            // We assume that an SSH key's ideal size is > 0 bytes && < 100 kilobytes.
+            if (fileSize > 100000 || fileSize == 0) {
                 throw IllegalArgumentException("Wrong file type selected")
             } else {
                 // Validate BEGIN and END markers
                 val lines = contentResolver.openInputStream(uri)?.bufferedReader()?.readLines()
-
-                // file must have more than 2 lines
-                // first line contains BEGIN
-                // last line contains END
+                // The file must have more than 2 lines, and the first and last line must have
+                // OpenSSH key markers.
                 if (lines != null &&
                     lines.size > 2 &&
                     !lines[0].contains("BEGIN OPENSSH PRIVATE KEY") &&

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -518,23 +518,23 @@ class UserPreference : AppCompatActivity() {
         startActivityForResult(intent, SET_CUSTOM_XKPWD_DICT)
     }
 
-    @Throws(IOException::class)
+    @Throws(IllegalArgumentException::class, IOException::class)
     private fun copySshKey(uri: Uri) {
         // See metadata from document to validate SSH key
         contentResolver.query(
                 uri, null, null, null, null, null
         )?.use { cursor ->
-            val sizeIndex: Int = cursor.getColumnIndex(OpenableColumns.SIZE)
+            val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
 
             // cursor returns only 1 row
             cursor.moveToFirst()
             // see file's metadata
-            val sizeFile: Int = cursor.getInt(sizeIndex)
+            val sizeFile = cursor.getInt(sizeIndex)
             val extensionFile = File(uri.path.toString()).extension
 
             // SSH key without file extension and size < than 100KB
-            if (extensionFile.isNotEmpty() || //
-                    sizeFile > 100000) //
+            if (extensionFile.isNotEmpty() ||
+                    sizeFile > 100000)
                 throw IllegalArgumentException("Wrong file type selected")
         }
 

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -532,12 +532,25 @@ class UserPreference : AppCompatActivity() {
             cursor.moveToFirst()
             // see file's metadata
             val sizeFile = cursor.getInt(sizeIndex)
-            val extensionFile = File(uri.path.toString()).extension
 
-            // SSH key without file extension and size < than 100KB
-            if (extensionFile.isNotEmpty() ||
-                    sizeFile > 100000)
+            // SSH key size < than 100KB and different from 0
+            if (sizeFile > 100000 ||
+                    sizeFile == 0)
                 throw IllegalArgumentException("Wrong file type selected")
+            else {
+                // Validate BEGIN and END markers
+                val lines = contentResolver.openInputStream(uri)?.bufferedReader()?.readLines()
+
+                // file must have more than 2 lines
+                // first line contains BEGIN
+                // last line contains END
+                if (lines != null &&
+                    lines.size > 2 &&
+                    !lines[0].contains("BEGIN") &&
+                    !lines[lines.size - 1].contains("END")) {
+                    throw IllegalArgumentException("Wrong file type selected")
+                }
+            }
         }
 
         val sshKeyInputStream = contentResolver.openInputStream(uri)

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -530,7 +530,6 @@ class UserPreference : AppCompatActivity() {
             cursor.moveToFirst()
             // see file's metadata
             val sizeFile = cursor.getInt(sizeIndex)
-
             // SSH key size < than 100KB and different from 0
             if (sizeFile > 100000 || sizeFile == 0) {
                 throw IllegalArgumentException("Wrong file type selected")

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -8,7 +8,6 @@ import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ShortcutManager
-import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -17,7 +16,6 @@ import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import android.provider.Settings
 import android.text.TextUtils
-import android.util.Log
 import android.view.MenuItem
 import android.view.accessibility.AccessibilityManager
 import android.widget.Toast
@@ -534,7 +532,7 @@ class UserPreference : AppCompatActivity() {
             val sizeFile: Int = cursor.getInt(sizeIndex)
             val extensionFile = File(uri.path.toString()).extension
 
-            //SSH key without file extension and size < than 100KB
+            // SSH key without file extension and size < than 100KB
             if (extensionFile.isNotEmpty() || //
                     sizeFile > 100000) //
                 throw IllegalArgumentException("Wrong file type selected")

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -76,7 +76,6 @@
     <string name="pref_show_time_title">مدة الإبقاء على كلمة السر ظاهرة</string>
     <string name="pref_copy_title">نسخ كلمة السر تلقائيًا</string>
     <string name="ssh_key_success_dialog_title">تم استيراد مفتاح الـ SSH</string>
-    <string name="ssh_key_error_dialog_title">حدث هناك خطأ أثناء عملية إسترجاع مفتاح الـ SSH</string>
     <string name="ssh_key_error_dialog_text">نص الرسالة : \n</string>
     <string name="pref_autofill_title">الملئ التلقائي</string>
     <string name="pref_autofill_enable_title">تشغيل الملئ التلقائي</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -119,7 +119,6 @@
     <string name="pref_copy_title">Automaticky kopírovat heslo</string>
     <string name="pref_copy_dialog_title">Automatické kopírování hesla do schránky po úspěšném dešifrování.</string>
     <string name="ssh_key_success_dialog_title">SSH-key importován</string>
-    <string name="ssh_key_error_dialog_title">Chyba při importu SSH klíče</string>
     <string name="ssh_key_error_dialog_text">Zpráva : \n</string>
     <string name="pref_recursive_filter">Rekurzivní filtrování</string>
     <string name="pref_recursive_filter_hint">Rekurzivní hledání hesel v aktuálním adresáři.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -94,7 +94,6 @@
     <string name="pref_copy_title">Kopiere Passwort automatisch</string>
     <string name="pref_copy_dialog_title">Kopiert das Passwort in die Zwischenablage, wenn der Eintrag entschlüsselt wurde.</string>
     <string name="ssh_key_success_dialog_title">SSH-Key importiert</string>
-    <string name="ssh_key_error_dialog_title">Fehler während des Imports des SSH-Keys</string>
     <string name="ssh_key_error_dialog_text">Nachricht : \n</string>
     <string name="pref_recursive_filter">Suche in Unterordnern</string>
     <string name="pref_recursive_filter_hint">Findet Passwörter auch in Unterordnern.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -120,7 +120,6 @@
     <string name="pref_copy_title">Copiar contraseña automáticamente</string>
     <string name="pref_copy_dialog_title">Automáticamente copia la contraseña al portapapeles si el descifrado fue exitoso.</string>
     <string name="ssh_key_success_dialog_title">Llave SSH importada</string>
-    <string name="ssh_key_error_dialog_title">Error al intentar importar llave SSH</string>
     <string name="ssh_key_error_dialog_text">Mensaje: \n</string>
     <string name="pref_recursive_filter">Búsqueda recursiva</string>
     <string name="pref_recursive_filter_hint">Busca contraseñas recursivamente en el directorio actual.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -128,7 +128,6 @@
     <string name="pref_copy_title">Copie automatique du mot de passe</string>
     <string name="pref_copy_dialog_title">Copie automatiquement le mot de passe vers le presse-papier si le déchiffrement a réussi.</string>
     <string name="ssh_key_success_dialog_title">Clef SSH importée</string>
-    <string name="ssh_key_error_dialog_title">Erreur lors de l\'importation du la clef ssh</string>
     <string name="ssh_key_error_dialog_text">Message : \n</string>
     <string name="pref_recursive_filter">Filtre récursif</string>
     <string name="pref_recursive_filter_hint">Cherche le mot de passe dans tous les sous-répertoires du répertoire actuel.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,7 +80,6 @@
     <string name="pref_copy_title">自動的にパスワードをコピー</string>
     <string name="pref_copy_dialog_title">復号化が成功した後、自動的にパスワードをクリップボードにコピーします。</string>
     <string name="ssh_key_success_dialog_title">SSH 鍵をインポートしました</string>
-    <string name="ssh_key_error_dialog_title">ssh 鍵のインポート時にエラー</string>
     <string name="ssh_key_error_dialog_text">メッセージ : \n</string>
     <string name="pref_recursive_filter">再帰的フィルタリング</string>
     <string name="pref_recursive_filter_hint">現在のディレクトリーのパスワードを再帰的に検索します。</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -134,7 +134,6 @@
     <string name="pref_copy_title">Автоматически копировать пароль</string>
     <string name="pref_copy_dialog_title">Автоматически копировать пароль в буфер обмена после успешного расшифрования</string>
     <string name="ssh_key_success_dialog_title">SSH ключ импортирован</string>
-    <string name="ssh_key_error_dialog_title">Ошибка импорта SSH ключа</string>
     <string name="ssh_key_error_dialog_text">Сообщение: \n</string>
     <string name="pref_recursive_filter">Рекурсивная фильтрация</string>
     <string name="pref_recursive_filter_hint">Рекурсивный поиск паролей в текущей директории</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -80,7 +80,6 @@
     <string name="pref_copy_title">自动复制密码</string>
     <string name="pref_copy_dialog_title">解密成功后自动将密码复制到剪贴板</string>
     <string name="ssh_key_success_dialog_title">成功导入SSH密钥</string>
-    <string name="ssh_key_error_dialog_title">尝试导入SSH密钥时出错</string>
     <string name="ssh_key_error_dialog_text">信息:</string>
     <string name="pref_recursive_filter">搜索子文件夹</string>
     <string name="pref_recursive_filter_hint">在当前目录的子目录中查找密码</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -77,7 +77,6 @@
     <string name="pref_copy_title">自動複製密碼</string>
     <string name="pref_copy_dialog_title">解密成功後自動將密碼複製到剪貼簿</string>
     <string name="ssh_key_success_dialog_title">成功匯入 SSH 金鑰</string>
-    <string name="ssh_key_error_dialog_title">嘗試匯入 SSH 金鑰時出錯</string>
     <string name="ssh_key_error_dialog_text">訊息:</string>
     <string name="pref_recursive_filter">搜尋子資料夾</string>
     <string name="pref_recursive_filter_hint">在目前目錄的子目錄中查詢密碼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="pref_copy_title">Automatically copy password</string>
     <string name="pref_copy_dialog_title">Automatically copy the password to the clipboard after decryption was successful.</string>
     <string name="ssh_key_success_dialog_title">SSH-key imported</string>
-    <string name="ssh_key_error_dialog_title">Error while trying to import the ssh-key</string>
+    <string name="ssh_key_error_dialog_title">Key import error</string>
     <string name="ssh_key_error_dialog_text">Message : \n</string>
     <string name="pref_recursive_filter">Recursive filtering</string>
     <string name="pref_recursive_filter_hint">Recursively find passwords of the current directory.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,4 +348,5 @@
     <string name="theme_dark">Dark</string>
     <string name="theme_battery_saver">Set by Battery Saver</string>
     <string name="theme_follow_system">System default</string>
+    <string name="ssh_key_import_error_not_an_ssh_key_message">Selected file does not appear to be an SSH key</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
To import a SSH key, first confirm its size and extension 
I think it would be a good validation to at least discard files that couldn't be keys.

## :bulb: Motivation and Context
**Why is this change required? What problem does it solve?**
Avoid being able to import any file as if it were a key.
Even though it doesn't solve the fact that it may not be a key, it limits the number of files that can also not be a key.

**If it fixes an open issue, please link to the issue here.**
[#619](https://github.com/android-password-store/Android-Password-Store/issues/619)

## :green_heart: How did you test it?
I tried to import different files sizes and extensions (.mp3, jpg, etc), only a private SSH key worked

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
