### PR TITLE
Update SSH clear passphrase preference to handle HTTPS

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -396,6 +396,7 @@ class UserPreference : AppCompatActivity() {
                     sshPass != null -> getString(R.string.clear_saved_passphrase_ssh)
                     else -> null
                 }
+                isVisible = true
             }
         }
 

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -184,7 +184,6 @@ class UserPreference : AppCompatActivity() {
                     else if (encryptedPreferences.getString("ssh_key_local_passphrase", null) != null)
                         remove("ssh_key_local_passphrase")
                 }
-                it.isVisible = false
                 updateClearSavedPassphrasePrefs()
                 true
             }
@@ -389,7 +388,7 @@ class UserPreference : AppCompatActivity() {
                 val httpsPass = encryptedPreferences.getString("https_password", null)
                 if (sshPass == null && httpsPass == null) {
                     isVisible = false
-                    return
+                    return@apply
                 }
                 title = when {
                     httpsPass != null -> getString(R.string.clear_saved_passphrase_https)

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -179,10 +179,10 @@ class UserPreference : AppCompatActivity() {
 
             clearSavedPassPreference?.onPreferenceClickListener = ClickListener {
                 encryptedPreferences.edit {
-                    if (encryptedPreferences.getString("ssh_key_local_passphrase", null) != null)
-                        remove("ssh_key_local_passphrase")
-                    else if (encryptedPreferences.getString("https_password", null) != null)
+                    if (encryptedPreferences.getString("https_password", null) != null)
                         remove("https_password")
+                    else if (encryptedPreferences.getString("ssh_key_local_passphrase", null) != null)
+                        remove("ssh_key_local_passphrase")
                 }
                 it.isVisible = false
                 updateClearSavedPassphrasePrefs()

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -24,6 +24,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.biometric.BiometricManager
+import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.documentfile.provider.DocumentFile
 import androidx.preference.CheckBoxPreference
@@ -177,8 +178,14 @@ class UserPreference : AppCompatActivity() {
             }
 
             clearSavedPassPreference?.onPreferenceClickListener = ClickListener {
-                encryptedPreferences.edit().putString("ssh_key_local_passphrase", null).apply()
+                encryptedPreferences.edit {
+                    if (encryptedPreferences.getString("ssh_key_local_passphrase", null) != null)
+                        remove("ssh_key_local_passphrase")
+                    else if (encryptedPreferences.getString("https_password", null) != null)
+                        remove("https_password")
+                }
                 it.isVisible = false
+                updateClearSavedPassphrasePrefs()
                 true
             }
 
@@ -385,8 +392,8 @@ class UserPreference : AppCompatActivity() {
                     return
                 }
                 title = when {
-                    sshPass != null -> getString(R.string.clear_saved_passphrase_ssh)
                     httpsPass != null -> getString(R.string.clear_saved_passphrase_https)
+                    sshPass != null -> getString(R.string.clear_saved_passphrase_ssh)
                     else -> null
                 }
             }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -8,6 +8,7 @@ import android.accessibilityservice.AccessibilityServiceInfo
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import android.content.SharedPreferences
 import android.content.pm.ShortcutManager
 import android.net.Uri
 import android.os.Build
@@ -67,15 +68,17 @@ class UserPreference : AppCompatActivity() {
 
     class PrefsFragment : PreferenceFragmentCompat() {
         private var autoFillEnablePreference: SwitchPreferenceCompat? = null
+        private var clearSavedPassPreference: Preference? = null
         private lateinit var autofillDependencies: List<Preference>
         private lateinit var oreoAutofillDependencies: List<Preference>
         private lateinit var callingActivity: UserPreference
+        private lateinit var encryptedPreferences: SharedPreferences
 
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             callingActivity = requireActivity() as UserPreference
             val context = requireContext()
             val sharedPreferences = preferenceManager.sharedPreferences
-            val encryptedPreferences = requireActivity().applicationContext.getEncryptedPrefs("git_operation")
+            encryptedPreferences = requireActivity().applicationContext.getEncryptedPrefs("git_operation")
 
             addPreferencesFromResource(R.xml.preference)
 
@@ -85,7 +88,7 @@ class UserPreference : AppCompatActivity() {
             val gitConfigPreference = findPreference<Preference>("git_config")
             val sshKeyPreference = findPreference<Preference>("ssh_key")
             val sshKeygenPreference = findPreference<Preference>("ssh_keygen")
-            val sshClearPassphrasePreference = findPreference<Preference>("ssh_key_clear_passphrase")
+            clearSavedPassPreference = findPreference("clear_saved_pass")
             val clearHotpIncrementPreference = findPreference<Preference>("hotp_remember_clear_choice")
             val viewSshKeyPreference = findPreference<Preference>("ssh_see_key")
             val deleteRepoPreference = findPreference<Preference>("git_delete_repo")
@@ -124,8 +127,6 @@ class UserPreference : AppCompatActivity() {
             selectExternalGitRepositoryPreference?.summary = sharedPreferences.getString("git_external_repo", getString(R.string.no_repo_selected))
             viewSshKeyPreference?.isVisible = sharedPreferences.getBoolean("use_generated_key", false)
             deleteRepoPreference?.isVisible = !sharedPreferences.getBoolean("git_external", false)
-            sshClearPassphrasePreference?.isVisible = encryptedPreferences.getString("ssh_key_local_passphrase", null)?.isNotEmpty()
-                    ?: false
             clearHotpIncrementPreference?.isVisible = sharedPreferences.getBoolean("hotp_remember_check", false)
             clearAfterCopyPreference?.isVisible = sharedPreferences.getString("general_show_time", "45")?.toInt() != 0
             clearClipboard20xPreference?.isVisible = sharedPreferences.getString("general_show_time", "45")?.toInt() != 0
@@ -142,6 +143,7 @@ class UserPreference : AppCompatActivity() {
                     ?: false
 
             updateAutofillSettings()
+            updateClearSavedPassphrasePrefs()
 
             appVersionPreference?.summary = "Version: ${BuildConfig.VERSION_NAME}"
 
@@ -174,7 +176,7 @@ class UserPreference : AppCompatActivity() {
                 true
             }
 
-            sshClearPassphrasePreference?.onPreferenceClickListener = ClickListener {
+            clearSavedPassPreference?.onPreferenceClickListener = ClickListener {
                 encryptedPreferences.edit().putString("ssh_key_local_passphrase", null).apply()
                 it.isVisible = false
                 true
@@ -374,6 +376,22 @@ class UserPreference : AppCompatActivity() {
             }
         }
 
+        private fun updateClearSavedPassphrasePrefs() {
+            clearSavedPassPreference?.apply {
+                val sshPass = encryptedPreferences.getString("ssh_key_local_passphrase", null)
+                val httpsPass = encryptedPreferences.getString("https_password", null)
+                if (sshPass == null && httpsPass == null) {
+                    isVisible = false
+                    return
+                }
+                title = when {
+                    sshPass != null -> getString(R.string.clear_saved_passphrase_ssh)
+                    httpsPass != null -> getString(R.string.clear_saved_passphrase_https)
+                    else -> null
+                }
+            }
+        }
+
         private fun onEnableAutofillClick() {
             if (callingActivity.isAccessibilityServiceEnabled) {
                 startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
@@ -431,6 +449,7 @@ class UserPreference : AppCompatActivity() {
         override fun onResume() {
             super.onResume()
             updateAutofillSettings()
+            updateClearSavedPassphrasePrefs()
         }
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,7 +216,6 @@
     <string name="git_push_nff_error">La subida fue rechazada por el servidor, Ejecuta \'Descargar desde servidor\' antes de subir o pulsa \'Sincronizar con servidor\' para realizar ambas acciones.</string>
     <string name="git_push_generic_error">El envío fue rechazado por el servidor, la razón:</string>
     <string name="jgit_error_push_dialog_text">Ocurrió un error durante el envío:</string>
-    <string name="ssh_key_clear_passphrase">Limpiar contraseña guardada de llave SSH</string>
     <string name="hotp_remember_clear_choice">Limpiar preferencia para incremento HOTP</string>
     <string name="remember_the_passphrase">Recordar contraseñagit  (inseguro)</string>
     <string name="hackish_tools">Hackish tools</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -217,7 +217,6 @@
     <string name="git_push_generic_error">Poussée rejetée par le dépôt distant, raison:</string>
     <string name="git_push_other_error">Pousser au dépôt distant sans avance rapide rejetée. Vérifiez la variable receive.denyNonFastForwards dans le fichier de configuration du répertoire de destination.</string>
     <string name="jgit_error_push_dialog_text">Une erreur s\'est produite lors de l\'opération de poussée:</string>
-    <string name="ssh_key_clear_passphrase">Effacer la phrase secrète enregistrée par ssh-key</string>
     <string name="hotp_remember_clear_choice">Effacer les préférences enregistrées pour l’incrémentation HOTP</string>
     <string name="remember_the_passphrase">Se rappeler de la phrase secrète dans la configuration de l\'application (peu sûr)</string>
     <string name="hackish_tools">Outils de hack</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -279,7 +279,6 @@
     <string name="git_push_generic_error">Запись изменений была отклонена удаленным репозиторием, причина:</string>
     <string name="git_push_other_error">Удаленный репозиторий отклонил запись изменений без быстрой перемотки вперед. Проверьте переменную receive.denyNonFastForwards в файле конфигурации репозитория назначения.</string>
     <string name="jgit_error_push_dialog_text">В хоте операции записи изменений возникла ошибка:</string>
-    <string name="ssh_key_clear_passphrase">Очистить сохраненную парольную фразу ключа ssh</string>
     <string name="hotp_remember_clear_choice">Очистить сохраненные настройки для увеличения HOTP</string>
     <string name="remember_the_passphrase">Заполнить парольную фразу в конфигурации приложнеия (небезопасно)</string>
     <string name="hackish_tools">Костыльные инструменты</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,7 +307,8 @@
     <string name="git_push_generic_error">Push was rejected by remote, reason:</string>
     <string name="git_push_other_error">Remote rejected non-fast-forward push. Check receive.denyNonFastForwards variable in config file of destination repository.</string>
     <string name="jgit_error_push_dialog_text">Error occurred during the push operation:</string>
-    <string name="ssh_key_clear_passphrase">Clear ssh-key saved passphrase</string>
+    <string name="clear_saved_passphrase_ssh">Clear saved passphrase for local SSH key</string>
+    <string name="clear_saved_passphrase_https">Clear saved HTTPS password</string>
     <string name="hotp_remember_clear_choice">Clear saved preference for HOTP incrementing</string>
     <string name="remember_the_passphrase">Remember key passphrase</string>
     <string name="hackish_tools">Hackish tools</string>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -45,9 +45,7 @@
         <androidx.preference.Preference
             app:key="ssh_keygen"
             app:title="@string/pref_ssh_keygen_title" />
-        <androidx.preference.Preference
-            app:key="ssh_key_clear_passphrase"
-            app:title="@string/ssh_key_clear_passphrase" />
+        <androidx.preference.Preference app:key="clear_saved_pass" />
         <androidx.preference.Preference
             app:key="hotp_remember_clear_choice"
             app:title="@string/hotp_remember_clear_choice" />


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Make clear SSH passphrase preference handle HTTPS by checking both preference keys and
updating title dynamically.

## :bulb: Motivation and Context
In #685 we added the option of being able to save both SSH and HTTPS passphrases/passwords
but the option to manually clear was only working for its old SSH-only scenario. Fix that.


## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
Currently the resume behavior path seems to not work and you need to exit and restart
the activity to see the preference after persisting passphrase. Repro steps:

- Clear existing saved passphrase if any
- Go to Git utils, and tap the 'hard reset to remote branch' button
- Enter your passphrase and ensure you save it
- The activity calls `finish()`, and returns to `UserPreference` but the preference does not show.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
