### PR TITLE
AutofillDecryptActivity: Show toast on Main dispatcher

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
@@ -212,11 +212,13 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
             OpenPgpApi.RESULT_CODE_ERROR -> {
                 val error = result.getParcelableExtra<OpenPgpError>(OpenPgpApi.RESULT_ERROR)
                 if (error != null) {
-                    Toast.makeText(
-                        applicationContext,
-                        "Error from OpenKeyChain: ${error.message}",
-                        Toast.LENGTH_LONG
-                    ).show()
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                                applicationContext,
+                                "Error from OpenKeyChain: ${error.message}",
+                                Toast.LENGTH_LONG
+                        ).show()
+                    }
                     e { "OpenPgpApi ACTION_DECRYPT_VERIFY failed (${error.errorId}): ${error.message}" }
                 }
                 null


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Switch to Main context before showing Toast to prevent crash

## :bulb: Motivation and Context
When an OpenKeychain error occurs the app attempts to notify user via a Toast but since
the entire thing is running on a IO coroutine scope we cannot do any UI related operations
here without switching context.

## :green_heart: How did you test it?
Attempt to fill in with a password file encrypted with a key that was
not in OpenKeychain.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
