### PR TITLE
Validate hostname protocol before saving

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -36,8 +36,8 @@ abstract class BaseGitActivity : AppCompatActivity() {
     lateinit var serverPath: String
     lateinit var username: String
     lateinit var email: String
-    var identityBuilder: SshApiSessionFactory.IdentityBuilder? = null
-    var identity: SshApiSessionFactory.ApiIdentity? = null
+    private var identityBuilder: SshApiSessionFactory.IdentityBuilder? = null
+    private var identity: SshApiSessionFactory.ApiIdentity? = null
     lateinit var settings: SharedPreferences
         private set
     private lateinit var encryptedSettings: SharedPreferences
@@ -102,7 +102,13 @@ abstract class BaseGitActivity : AppCompatActivity() {
             Protocol.Https -> {
                 val portPart =
                     if (serverPort == "443" || serverPort.isEmpty()) "" else ":$serverPort"
-                "https://$hostnamePart$portPart$pathPart"
+                var result = "$hostnamePart$portPart$pathPart"
+                result = when {
+                    result.startsWith("http://") -> result.replace("http:", "https:")
+                    !result.startsWith("http") -> "https://$result"
+                    else -> result
+                }
+                result
             }
         }
         if (PasswordRepository.isInitialized)

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -20,6 +20,7 @@ import com.zeapo.pwdstore.git.config.SshApiSessionFactory
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import java.io.File
+import java.net.URL
 import timber.log.Timber
 
 /**
@@ -103,9 +104,10 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 val portPart =
                     if (serverPort == "443" || serverPort.isEmpty()) "" else ":$serverPort"
                 var result = "$hostnamePart$portPart$pathPart"
-                result = when {
-                    result.startsWith("http://") -> result.replace("http:", "https:")
-                    !result.startsWith("http") -> "https://$result"
+                val url = URL(result)
+                result = when (url.protocol) {
+                    null -> "https://$result"
+                    "http" -> result.replace("http:", "https:")
                     else -> result
                 }
                 result

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -20,6 +20,7 @@ import com.zeapo.pwdstore.git.config.SshApiSessionFactory
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import java.io.File
+import java.net.MalformedURLException
 import java.net.URL
 import timber.log.Timber
 
@@ -98,19 +99,31 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 val portPart =
                     if (serverPort == "22" || serverPort.isEmpty()) "" else ":$serverPort"
                 // We have to specify the ssh scheme as this is the only way to pass a custom port.
-                "ssh://$userPart$hostnamePart$portPart$pathPart"
+                val urlWithFreeEntryScheme = "$userPart$hostnamePart$portPart$pathPart"
+                val parsedUrl = try {
+                    URL(urlWithFreeEntryScheme)
+                } catch (_: MalformedURLException) {
+                    return false
+                }
+                if (parsedUrl.protocol == null)
+                    "ssh://$urlWithFreeEntryScheme"
+                else
+                    urlWithFreeEntryScheme
             }
             Protocol.Https -> {
                 val portPart =
                     if (serverPort == "443" || serverPort.isEmpty()) "" else ":$serverPort"
-                var result = "$hostnamePart$portPart$pathPart"
-                val url = URL(result)
-                result = when (url.protocol) {
-                    null -> "https://$result"
-                    "http" -> result.replace("http:", "https:")
-                    else -> result
+                val urlWithFreeEntryScheme = "$hostnamePart$portPart$pathPart"
+                val parsedUrl = try {
+                    URL(urlWithFreeEntryScheme)
+                } catch (_: MalformedURLException) {
+                    return false
                 }
-                result
+                when (parsedUrl.protocol) {
+                    null -> "https://$urlWithFreeEntryScheme"
+                    "http" -> urlWithFreeEntryScheme.replaceFirst("http:", "https:")
+                    else -> urlWithFreeEntryScheme
+                }
             }
         }
         if (PasswordRepository.isInitialized)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Extremely crude valiation of the protocol section of the given hostname. This was hastily thrown together and ideally the final result should look nothing like this.


## :bulb: Motivation and Context
Entering `https://github.com` in hostname will currently set the remote to `https://https://github.com` and break operations, which is rather undesirable.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
Possibly validate Ssh path similarly.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
