### PR TITLE
release/deploy-snapshot: Don't swallow errors

### DIFF
--- a/release/deploy-snapshot.sh
+++ b/release/deploy-snapshot.sh
@@ -7,5 +7,5 @@ chmod 600 "$SSHDIR/key"
 export SERVER_DEPLOY_STRING="$SSH_USERNAME@$SERVER_ADDRESS:$SERVER_DESTINATION"
 cd "$GITHUB_WORKSPACE/app/build/outputs/apk/release"
 rm output.json
-rsync -ahvcr --omit-dir-times --progress --delete --no-o --no-g -e "ssh -i $SSHDIR/key -o StrictHostKeyChecking=no -p $SSH_PORT" . "$SERVER_DEPLOY_STRING" || true
+rsync -ahvcr --omit-dir-times --progress --delete --no-o --no-g -e "ssh -i $SSHDIR/key -o StrictHostKeyChecking=no -p $SSH_PORT" . "$SERVER_DEPLOY_STRING" || exit 1
 exit 0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Exit with error on rsync failure to avoid deployment problems from going unnnoticed.

## :bulb: Motivation and Context

Due to an earlier problem that has since been resolved, the script was set to swallow every
rsync error and allow build to pass, which was incredibly stupid in hindsight and allowed
the failure of snapshot deployment to go under the radar for this long.

## :green_heart: How did you test it?

Added a [commit](https://github.com/android-password-store/Android-Password-Store/commit/d39bcc3002b3188287a696bbb336b72bd5545834) that changed deployment directory to `snapshot-fix-testing` and ran the `deploy_snapshot` task on this branch, Actions reports [success](https://github.com/android-password-store/Android-Password-Store/runs/599261904?check_suite_focus=true) and the directory was [correctly deployed](https://dl.msfjarvis.dev/snapshot-fix-testing/) to the server.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
