### PR TITLE
Fix protocol validation

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -119,8 +119,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
         try {
             if (URI(newUrl).rawAuthority == null)
                 return false
-        } catch (ex: MalformedURLException) {
-            e(ex)
+        } catch (_: MalformedURLException) {
             return false
         }
         if (PasswordRepository.isInitialized)

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -23,8 +23,8 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import java.io.File
 import java.net.MalformedURLException
-import timber.log.Timber
 import java.net.URI
+import timber.log.Timber
 
 /**
  * Abstract AppCompatActivity that holds some information that is commonly shared across git-related
@@ -111,7 +111,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 val urlWithFreeEntryScheme = "$hostnamePart$portPart$pathPart"
                 when {
                     urlWithFreeEntryScheme.startsWith("https://") -> urlWithFreeEntryScheme
-                    urlWithFreeEntryScheme.startsWith("http://")-> urlWithFreeEntryScheme.replaceFirst("http", "https")
+                    urlWithFreeEntryScheme.startsWith("http://") -> urlWithFreeEntryScheme.replaceFirst("http", "https")
                     else -> "https://$urlWithFreeEntryScheme"
                 }
             }

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -4,6 +4,7 @@
  */
 package com.zeapo.pwdstore.git
 
+import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -13,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import androidx.core.text.isDigitsOnly
 import androidx.preference.PreferenceManager
+import com.github.ajalt.timberkt.e
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.git.config.ConnectionMode
 import com.zeapo.pwdstore.git.config.Protocol
@@ -23,6 +25,7 @@ import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import timber.log.Timber
+import java.net.URI
 
 /**
  * Abstract AppCompatActivity that holds some information that is commonly shared across git-related
@@ -31,7 +34,7 @@ import timber.log.Timber
 abstract class BaseGitActivity : AppCompatActivity() {
     lateinit var protocol: Protocol
     lateinit var connectionMode: ConnectionMode
-    lateinit var url: String
+    var url: String? = null
     lateinit var serverHostname: String
     lateinit var serverPort: String
     lateinit var serverUser: String
@@ -90,48 +93,46 @@ abstract class BaseGitActivity : AppCompatActivity() {
         if (serverHostname.isEmpty() || !serverPort.isDigitsOnly())
             return false
 
-        val previousUrl = if (::url.isInitialized) url else ""
+        val previousUrl = url ?: ""
         val hostnamePart = serverHostname
         val pathPart = if (serverPath.startsWith('/')) serverPath else "/$serverPath"
-        url = when (protocol) {
+        val newUrl = when (protocol) {
             Protocol.Ssh -> {
                 val userPart = if (serverUser.isEmpty()) "" else "$serverUser@"
                 val portPart =
                     if (serverPort == "22" || serverPort.isEmpty()) "" else ":$serverPort"
                 // We have to specify the ssh scheme as this is the only way to pass a custom port.
                 val urlWithFreeEntryScheme = "$userPart$hostnamePart$portPart$pathPart"
-                val parsedUrl = try {
-                    URL(urlWithFreeEntryScheme)
-                } catch (_: MalformedURLException) {
-                    return false
-                }
-                if (parsedUrl.protocol == null)
-                    "ssh://$urlWithFreeEntryScheme"
-                else
+                if (urlWithFreeEntryScheme.startsWith("ssh://"))
                     urlWithFreeEntryScheme
+                else
+                    "ssh://$urlWithFreeEntryScheme"
             }
             Protocol.Https -> {
                 val portPart =
                     if (serverPort == "443" || serverPort.isEmpty()) "" else ":$serverPort"
                 val urlWithFreeEntryScheme = "$hostnamePart$portPart$pathPart"
-                val parsedUrl = try {
-                    URL(urlWithFreeEntryScheme)
-                } catch (_: MalformedURLException) {
-                    return false
-                }
-                when (parsedUrl.protocol) {
-                    null -> "https://$urlWithFreeEntryScheme"
-                    "http" -> urlWithFreeEntryScheme.replaceFirst("http:", "https:")
-                    else -> urlWithFreeEntryScheme
+                when {
+                    urlWithFreeEntryScheme.startsWith("https://") -> urlWithFreeEntryScheme
+                    urlWithFreeEntryScheme.startsWith("http://")-> urlWithFreeEntryScheme.replaceFirst("http", "https")
+                    else -> "https://$urlWithFreeEntryScheme"
                 }
             }
         }
+        try {
+            if (URI(newUrl).rawAuthority == null)
+                return false
+        } catch (ex: MalformedURLException) {
+            e(ex)
+            return false
+        }
         if (PasswordRepository.isInitialized)
-            PasswordRepository.addRemote("origin", url, true)
+            PasswordRepository.addRemote("origin", newUrl, true)
         // HTTPS authentication sends the password to the server, so we must wipe the password when
         // the server is changed.
-        if (url != previousUrl && protocol == Protocol.Https)
+        if (newUrl != previousUrl && protocol == Protocol.Https)
             encryptedSettings.edit { remove("https_password") }
+        url = newUrl
         return true
     }
 
@@ -145,8 +146,11 @@ abstract class BaseGitActivity : AppCompatActivity() {
      * @param operation The type of git operation to launch
      */
     fun launchGitOperation(operation: Int) {
-        val op: GitOperation
-        val localDir = requireNotNull(PasswordRepository.getRepositoryDirectory(this))
+        if (url == null) {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+            return
+        }
         try {
             // Before launching the operation with OpenKeychain auth, we need to issue several requests
             // to the OpenKeychain API. IdentityBuild will take care of launching the relevant intents,
@@ -163,8 +167,9 @@ abstract class BaseGitActivity : AppCompatActivity() {
                     return
             }
 
-            op = when (operation) {
-                REQUEST_CLONE, GitOperation.GET_SSH_KEY_FROM_CLONE -> CloneOperation(localDir, this).setCommand(url)
+            val localDir = requireNotNull(PasswordRepository.getRepositoryDirectory(this))
+            val op = when (operation) {
+                REQUEST_CLONE, GitOperation.GET_SSH_KEY_FROM_CLONE -> CloneOperation(localDir, this).setCommand(url!!)
                 REQUEST_PULL -> PullOperation(localDir, this).setCommand()
                 REQUEST_PUSH -> PushOperation(localDir, this).setCommand()
                 REQUEST_SYNC -> SyncOperation(localDir, this).setCommands()

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -23,7 +23,6 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import java.io.File
 import java.net.MalformedURLException
-import java.net.URL
 import timber.log.Timber
 import java.net.URI
 
@@ -101,12 +100,10 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 val userPart = if (serverUser.isEmpty()) "" else "$serverUser@"
                 val portPart =
                     if (serverPort == "22" || serverPort.isEmpty()) "" else ":$serverPort"
+                if (hostnamePart.startsWith("ssh://"))
+                    hostnamePart.replace("ssh://", "")
                 // We have to specify the ssh scheme as this is the only way to pass a custom port.
-                val urlWithFreeEntryScheme = "$userPart$hostnamePart$portPart$pathPart"
-                if (urlWithFreeEntryScheme.startsWith("ssh://"))
-                    urlWithFreeEntryScheme
-                else
-                    "ssh://$urlWithFreeEntryScheme"
+                "ssh://$userPart$hostnamePart$portPart$pathPart"
             }
             Protocol.Https -> {
                 val portPart =

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
@@ -183,9 +183,8 @@ abstract class GitOperation(fileDir: File, internal val callingActivity: Activit
                                     .setView(dialogView)
                                     .setPositiveButton(callingActivity.resources.getString(R.string.dialog_ok)) { _, _ ->
                                         if (keyPair.decrypt(passphrase.text.toString())) {
-                                            val rememberPassphrase = dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_passphrase).isChecked
-                                            if (rememberPassphrase) {
-                                                encryptedSettings.edit().putString("ssh_key_local_passphrase", passphrase.text.toString()).apply()
+                                            if (dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_passphrase).isChecked) {
+                                                encryptedSettings.edit { putString("ssh_key_local_passphrase", passphrase.text.toString()) }
                                             }
                                             // Authenticate using the ssh-key and then execute the command
                                             setAuthentication(sshKey, username, passphrase.text.toString()).execute()
@@ -233,9 +232,8 @@ abstract class GitOperation(fileDir: File, internal val callingActivity: Activit
                         .setMessage(callingActivity.resources.getString(R.string.password_dialog_text))
                         .setView(dialogView)
                         .setPositiveButton(callingActivity.resources.getString(R.string.dialog_ok)) { _, _ ->
-                            val rememberPassphrase = dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_passphrase).isChecked
-                            if (rememberPassphrase) {
-                                encryptedSettings.edit().putString("https_password", passwordView.text.toString()).apply()
+                            if (dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_passphrase).isChecked) {
+                                encryptedSettings.edit { putString("https_password", passwordView.text.toString()) }
                             }
                             // authenticate using the user/pwd and then execute the command
                             setAuthentication(username, passwordView.text.toString()).execute()

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperationActivity.kt
@@ -50,7 +50,7 @@ open class GitOperationActivity : BaseGitActivity() {
      * @param operation the operation to execute can be REQUEST_PULL or REQUEST_PUSH
      */
     private fun syncRepository(operation: Int) {
-        if (serverUser.isEmpty() || serverHostname.isEmpty() || url.isEmpty())
+        if (serverUser.isEmpty() || serverHostname.isEmpty() || url.isNullOrEmpty())
             MaterialAlertDialogBuilder(this)
                     .setMessage(getString(R.string.set_information_dialog_text))
                     .setPositiveButton(getString(R.string.dialog_positive)) { _, _ ->
@@ -65,7 +65,7 @@ open class GitOperationActivity : BaseGitActivity() {
                     .show()
         else {
             // check that the remote origin is here, else add it
-            PasswordRepository.addRemote("origin", url, true)
+            PasswordRepository.addRemote("origin", url!!, true)
             launchGitOperation(operation)
         }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Switch to `java.net.URI` for validation of server config and deal with the case where
server config is invalid, leaving the `url` field in `BaseGitActivity` uninitialized.

## :bulb: Motivation and Context
`java.net.URL` cannot handle `ssh://` types and was always reporting SSH configurations
as broken. It also always requires a protocol so we cannot use it to know if we need to add
a protocol to the URL.

## :green_heart: How did you test it?
Attempt to save various SSH and HTTPS configurations and verify that they
succeed when they should.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
