### PR TITLE
BaseGitActivity: don't remove saved password unnecessarily

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -126,7 +126,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
             PasswordRepository.addRemote("origin", newUrl, true)
         // HTTPS authentication sends the password to the server, so we must wipe the password when
         // the server is changed.
-        if (newUrl != previousUrl && protocol == Protocol.Https)
+        if (previousUrl.isNotEmpty() && newUrl != previousUrl && protocol == Protocol.Https)
             encryptedSettings.edit { remove("https_password") }
         url = newUrl
         return true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Don't clear `https_password` when `updateUrl` is called for the first time. Fixed #725.

## :bulb: Motivation and Context
when `updateUrl` is first called, it tries to fill `previousUrl` with the class variable
`url` but since `url` is going to be initialized later in this method, `previousUrl` is
left empty. This has the unfortunate side affect that our logic to remove saved HTTPS
password on hostname change is always triggered in this first pass of `updateUrl`, resulting
in users always being prompted for their password.

## :green_heart: How did you test it?
Manually verify HTTPS password is correctly persisted on future invocations of `GitOperation`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
`R E L E A S E`

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
