### PR TITLE
Never obscure OK button in Autofill onboarding UI

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -133,7 +133,7 @@ class PasswordStore : AppCompatActivity() {
                 @SuppressLint("InflateParams")
                 val layout =
                         layoutInflater.inflate(R.layout.oreo_autofill_instructions, null)
-                layout.findViewById<AppCompatTextView>(R.id.intro_text).visibility = View.GONE
+                layout.findViewById<AppCompatTextView>(R.id.intro_text).setText(R.string.autofill_onboarding_dialog_message)
                 val supportedBrowsersTextView =
                         layout.findViewById<AppCompatTextView>(R.id.supportedBrowsers)
                 supportedBrowsersTextView.text =
@@ -152,7 +152,6 @@ class PasswordStore : AppCompatActivity() {
                         }
                 setView(layout)
                 setTitle(getString(R.string.autofill_onboarding_dialog_title))
-                setMessage(getString(R.string.autofill_onboarding_dialog_message))
                 setPositiveButton(R.string.dialog_ok) { _, _ ->
                     settings.edit { putBoolean("seen_autofill_onboarding", true) }
                     startActivity(Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE).apply {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
If there are many (4+) supported browsers installed, the OK button in the Autofill onboarding dialog is obscured by the browser list.

This commit addresses this issue by not using `setMessage` based on this comment: https://stackoverflow.com/a/48299165/297261.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I have many browsers installed but still see the OK button.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
