### PR TITLE
Improve permission handling logic

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -395,35 +395,21 @@ class PasswordStore : AppCompatActivity() {
      */
     private fun hasRequiredStoragePermissions(checkLocalRepo: Boolean = false): Boolean {
         return if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            != PackageManager.PERMISSION_GRANTED
-        ) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(
-                    activity,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
-            ) {
-                Snackbar.make(
+            != PackageManager.PERMISSION_GRANTED) {
+            Snackbar.make(
                     findViewById(R.id.main_layout),
                     getString(R.string.access_sdcard_text),
                     Snackbar.LENGTH_INDEFINITE
-                ).run {
-                    setAction(R.string.dialog_ok) {
-                        ActivityCompat.requestPermissions(
+            ).run {
+                setAction(getString(R.string.snackbar_action_grant)) {
+                    ActivityCompat.requestPermissions(
                             activity,
                             arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
                             REQUEST_EXTERNAL_STORAGE
-                        )
-                        dismiss()
-                    }
-                    show()
+                    )
+                    dismiss()
                 }
-            } else {
-                // No explanation needed, we can request the permission.
-                ActivityCompat.requestPermissions(
-                    activity,
-                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-                    REQUEST_EXTERNAL_STORAGE
-                )
+                show()
             }
             false
         } else {

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -461,6 +461,12 @@ class UserPreference : AppCompatActivity() {
         }
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+        setResult(Activity.RESULT_OK)
+        finish()
+    }
+
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         when (intent?.getStringExtra("operation")) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -303,7 +303,6 @@
     <string name="biometric_auth_summary">Когда ключено, Password Store будет запрашивать ваш опечаток пальца при каждом запуске приложения</string>
     <string name="biometric_auth_summary_error">Сенсор отпечатка пальца не доступен или отсутствует</string>
     <string name="ssh_openkeystore_clear_keyid">Очистить сохраненный SSH Key идентификатор OpenKystortore</string>
-    <string name="access_sdcard_text">Хранилище находится на sd-карте, но приложение не имеет прав доступа к ней. Пожалуйста, дайте приложению необходимые разрешения.</string>
     <string name="your_public_key">Ваш публичный ключ</string>
     <string name="error_generate_ssh_key">Возникла ошибка при попытке генерации ssh ключа</string>
     <string name="pref_show_hidden_title">Показать скрытые папки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,7 +333,7 @@
     <string name="biometric_auth_summary">When enabled, Password Store will prompt you for your fingerprint when launching the app</string>
     <string name="biometric_auth_summary_error">Fingerprint hardware not accessible or missing</string>
     <string name="ssh_openkeystore_clear_keyid">Clear remembered OpenKeystore SSH Key ID</string>
-    <string name="access_sdcard_text">The store is on the sdcard but the app does not have permission to access it. Please give permission.</string>
+    <string name="access_sdcard_text">The store location is in your SD Card/Internal Storage, but the app does not have permission to access it.</string>
     <string name="your_public_key">Your public key</string>
     <string name="error_generate_ssh_key">Error while trying to generate the ssh-key</string>
     <string name="pref_show_hidden_title">Show hidden folders</string>
@@ -364,4 +364,5 @@
     <string name="bottom_sheet_create_new_password">Create new password</string>
     <string name="autofill_onboarding_dialog_title">New, revamped Autofill!</string>
     <string name="autofill_onboarding_dialog_message">In this release, Autofill support has been massively improved with advanced features like anti-phishing protection and enhanced reliability. If you have been holding out on using it because of the shortcomings on the previous version, you\'ll likely love the new iteration. Give it a shot!</string>
+    <string name="snackbar_action_grant">Grant</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,7 +333,7 @@
     <string name="biometric_auth_summary">When enabled, Password Store will prompt you for your fingerprint when launching the app</string>
     <string name="biometric_auth_summary_error">Fingerprint hardware not accessible or missing</string>
     <string name="ssh_openkeystore_clear_keyid">Clear remembered OpenKeystore SSH Key ID</string>
-    <string name="access_sdcard_text">The store location is in your SD Card/Internal Storage, but the app does not have permission to access it.</string>
+    <string name="access_sdcard_text">The store location is in your SD Card or Internal storage, but the app does not have permission to access it.</string>
     <string name="your_public_key">Your public key</string>
     <string name="error_generate_ssh_key">Error while trying to generate the ssh-key</string>
     <string name="pref_show_hidden_title">Show hidden folders</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Ensure storage permission is always requested when it is needed, also improve the flow around this for better UX.

## :bulb: Motivation and Context
Fixes #730

## :green_heart: How did you test it?
Copied my password store to `/sdcard/`, tried to load it using the steps in #730 and
was prompted for storage permissions rather than crashing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps
A lot of logic here is complex and unnecessarily tied to `UserPreference` so a refactor is in order
to move things out of it.

## :camera_flash: Screenshots / GIFs

<details>
<summary>Old permission grant flow</summary>

![permission_flow_old](https://user-images.githubusercontent.com/13348378/80003436-adb2be00-84de-11ea-978a-bbe9a471b34c.gif)


</details>

<details>
<summary>New permission grant flow</summary>

![permission_flow](https://user-images.githubusercontent.com/13348378/80003429-aa1f3700-84de-11ea-95da-84889e4d27b9.gif)

</details>
