### PR TITLE
Fix crash when using type independent sort

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -92,7 +92,9 @@ private fun PasswordItem.Companion.makeComparator(
 ): Comparator<PasswordItem> {
     return when (typeSortOrder) {
         PasswordRepository.PasswordSortOrder.FOLDER_FIRST -> compareBy { it.type }
-        PasswordRepository.PasswordSortOrder.INDEPENDENT -> compareBy<PasswordItem>()
+        // In order to let INDEPENDENT not distinguish between items based on their type, we simply
+        // declare them all equal at this stage.
+        PasswordRepository.PasswordSortOrder.INDEPENDENT -> Comparator<PasswordItem> { _, _ -> 0 }
         PasswordRepository.PasswordSortOrder.FILE_FIRST -> compareByDescending { it.type }
     }
         .then(compareBy(nullsLast(CaseInsensitiveComparator)) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
No longer crash APS when using the "Type independent" password item sort order.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #733.

## :green_heart: How did you test it?
The app no longer crashes and sorts correctly.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
