### PR TITLE
Prepare v1.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.1] - 2020-04-23
+
+### Fixed
+- Autofill message does not show OK button when many browsers are installed
+- Autofill message does not get marked as shown when dismissed
+- App crashes when using type-independent sort
+- Storage permission not requested when using existing external repository
+
 ## [1.7.0] - 2020-04-21
 
 ### Added
@@ -102,7 +110,8 @@ All notable changes to this project will be documented in this file.
 - Fix elements overlapping.
 
 
-[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.0..v1.7.1
 [1.7.0]: https://github.com/android-password-store/Android-Password-Store/compare/v1.6.0..v1.7.0
 [1.6.0]: https://github.com/android-password-store/Android-Password-Store/compare/v1.5.0..v1.6.0
 [1.5.0]: https://github.com/android-password-store/Android-Password-Store/compare/v1.4.0...v1.5.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This application tries to be 100% compatible with [pass](http://www.passwordstor
 
 You can install the application from:
 
-* [F-Droid](https://f-droid.org/repository/browse/?fdid=com.zeapo.pwdstore)
+<!--* [F-Droid](https://f-droid.org/repository/browse/?fdid=com.zeapo.pwdstore)-->
 * [Play Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps)
 * [Snapshot builds](https://dl.msfjarvis.dev/APS/)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
 
     defaultConfig {
         applicationId versions.packageName
-        versionCode 10701
-        versionName '1.8.0-SNAPSHOT'
+        versionCode 10710
+        versionName '1.7.1'
     }
 
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
 
     defaultConfig {
         applicationId versions.packageName
-        versionCode 10710
-        versionName '1.7.1'
+        versionCode 10711
+        versionName '1.8.0-SNAPSHOT'
     }
 
     lintOptions {

--- a/release/deploy-github.sh
+++ b/release/deploy-github.sh
@@ -5,4 +5,4 @@ trap 'exit 1' SIGINT SIGTERM
 [ -z "$(command -v hub)" ] && { echo "hub not installed; aborting!"; exit 1; }
 [ -z "${1}" ] && { echo "No tag specified!"; exit 1; }
 gradle clean bundleRelease assembleRelease
-hub release create "${TAG}" -a app/build/outputs/apk/release/app-release.apk
+hub release create "${1}" -a app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
I've also updated the README to unlist F-Droid for now since the release is far too old
and we've fixed a large chunk of the major bugs in those versions, so I'd much rather
people not use those builds.
