### PR TITLE
Fix search if external root dir starts with a dot

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -266,7 +266,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
 
     private fun listFilesRecursively(dir: File): Flow<File> {
         return dir
-            .walkTopDown().onEnter { file -> shouldTake(file) }
+            .walkTopDown().onEnter { file -> if (file == dir) true else shouldTake(file) }
             .asFlow()
             // Skip the root directory
             .drop(1)

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -266,7 +266,8 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
 
     private fun listFilesRecursively(dir: File): Flow<File> {
         return dir
-            .walkTopDown().onEnter { file -> if (file == dir) true else shouldTake(file) }
+            // Take top directory even if it is hidden.
+            .walkTopDown().onEnter { file -> file == dir || shouldTake(file) }
             .asFlow()
             // Skip the root directory
             .drop(1)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
This PR aims to not filter out the root folder.

## :bulb: Motivation and Context
This PR fixes a small bug I encountered.
My repository is located at /storage/emulated/0/.password-store.

However, in the autofill popup, since that my root folder is hidden, it is filtered out.
So the autofill menu was empty.

Edit: Fixes #740.

## :green_heart: How did you test it?
I checked that the autofill menu now shows entries

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
