### PR TITLE
Add toggle for debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Settings option to enable debug logging
+
 ### Changed
 - SSH Keygen UI was improved
 - Default key length for SSH Keygen is now 4096 bits

--- a/app/src/main/java/com/zeapo/pwdstore/Application.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/Application.kt
@@ -21,11 +21,11 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
 
     override fun onCreate() {
         super.onCreate()
-        if (BuildConfig.ENABLE_DEBUG_FEATURES) {
+        prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (BuildConfig.ENABLE_DEBUG_FEATURES || prefs?.getBoolean("enable_debug_logging", false) == true) {
             plant(DebugTree())
             WhatTheStack(this).init()
         }
-        prefs = PreferenceManager.getDefaultSharedPreferences(this)
         prefs?.registerOnSharedPreferenceChangeListener(this)
         setNightMode()
     }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -282,6 +282,8 @@ class UserPreference : AppCompatActivity() {
                 getString(R.string.pref_clipboard_timeout_summary, sharedPreferences.getString("general_show_time", "45"))
             }
 
+            findPreference<CheckBoxPreference>("enable_debug_logging")?.isVisible = !BuildConfig.ENABLE_DEBUG_FEATURES
+
             findPreference<CheckBoxPreference>("biometric_auth")?.apply {
                 val isFingerprintSupported = BiometricManager.from(requireContext()).canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS
                 if (!isFingerprintSupported) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,4 +367,6 @@
     <string name="autofill_onboarding_dialog_title">New, revamped Autofill!</string>
     <string name="autofill_onboarding_dialog_message">In this release, Autofill support has been massively improved with advanced features like anti-phishing protection and enhanced reliability. If you have been holding out on using it because of the shortcomings on the previous version, you\'ll likely love the new iteration. Give it a shot!</string>
     <string name="snackbar_action_grant">Grant</string>
+    <string name="pref_debug_logging_summary">Enable debug logging (requires app restart)</string>
+    <string name="pref_debug_logging_title">Debug logging</string>
 </resources>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -172,6 +172,11 @@
             app:key="clear_clipboard_20x"
             app:summary="@string/pref_clear_clipboard_hint"
             app:title="@string/pref_clear_clipboard_title" />
+        <CheckBoxPreference
+            app:defaultValue="false"
+            app:key="enable_debug_logging"
+            app:summary="@string/pref_debug_logging_summary"
+            app:title="@string/pref_debug_logging_title" />
     </PreferenceCategory>
 
     <PreferenceCategory>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Add a preference option to enable Timber logging and initialize WhatTheStack

## :bulb: Motivation and Context

Fixes #285

## :green_heart: How did you test it?
Install release build with `ENABLE_DEBUG_FEATURES` turned off, start logging then toggle
config option and restart app. WhatTheStack process is created and all logging is recorded
which was not the case before toggling"

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
