### PR TITLE
Fix Autofill icons in dark mode

### DIFF
--- a/app/src/main/res/drawable/ic_person_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_person_black_24dp.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
         android:width="24dp"
         android:height="24dp"
-        android:tint="?colorOnPrimary"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/layout/oreo_autofill_dataset.xml
+++ b/app/src/main/res/layout/oreo_autofill_dataset.xml
@@ -12,6 +12,7 @@
     <ImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
+        android:tint="@color/secondary_color"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginEnd="10dp"

--- a/app/src/main/res/layout/oreo_autofill_filter_row.xml
+++ b/app/src/main/res/layout/oreo_autofill_filter_row.xml
@@ -15,6 +15,7 @@
         android:layout_marginStart="8dp"
         android:alpha="0.5"
         android:src="@drawable/ic_person_black_24dp"
+        android:tint="?colorOnPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/title"
         app:layout_constraintHorizontal_bias="0.0"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Use orange icons in Autofill datasets since they look good in both light and dark mode. Since the person icon is used both for datasets and in the filter view, its tint needs to be set in the layout rather than the drawable itself.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
RemoteViews are limited and do not support styles. In order to have them look great in both light and dark mode, there are only two approaches:

1. Use an icon color that works well on both light and dark backgrounds (what we are now doing).
2. Use `setLightBackgroundLayoutId` to set a separate RemoteViews layout in dark mode. This is more complex and necessarily introduces layout duplication, hence I would only go this way if really necessary.

## :green_heart: How did you test it?
Take a look at the screenshots.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<details>
  <summary>Screenshots</summary>
  
![Screenshot_20200428-083421](https://user-images.githubusercontent.com/4312191/80456862-98022600-892e-11ea-9dfe-ffd952b8ad5f.jpg)
![Screenshot_20200428-083450](https://user-images.githubusercontent.com/4312191/80456864-99335300-892e-11ea-9acd-4fb397809e45.jpg)

</details>
