### PR TITLE
Update Actions caching and add workflow to validate Gradle wrapper

### DIFF
--- a/.github/checksum.sh
+++ b/.github/checksum.sh
@@ -7,7 +7,7 @@ fi
 touch $RESULT_FILE
 
 checksum_file() {
-  echo $(openssl md5 $1 | awk '{print $2}')
+  echo $(sha256sum $1 | awk '{print $1}')
 }
 
 FILES=()

--- a/.github/checksum.sh
+++ b/.github/checksum.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+RESULT_FILE=$1
+
+if [ -f $RESULT_FILE ]; then
+  rm $RESULT_FILE
+fi
+touch $RESULT_FILE
+
+checksum_file() {
+  echo $(openssl md5 $1 | awk '{print $2}')
+}
+
+FILES=()
+while read -r -d ''; do
+	FILES+=("$REPLY")
+done < <(find . -type f \( -name "build.gradle*" -o -name "dependencies.gradle" -o -name "gradle-wrapper.properties" \) -print0)
+
+# Loop through files and append MD5 to result file
+for FILE in ${FILES[@]}; do
+	echo $(checksum_file $FILE) >> $RESULT_FILE
+done
+# Now sort the file so that it is
+sort $RESULT_FILE -o $RESULT_FILE

--- a/.github/workflows/branch_deploy.yml
+++ b/.github/workflows/branch_deploy.yml
@@ -20,10 +20,32 @@ jobs:
     - name: Copy CI gradle.properties
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-    - uses: actions/cache@v1
+    - name: Generate cache key
+      run: ./.github/checksum.sh checksum.txt
+
+    - name: Cache gradle modules
+      uses: actions/cache@v1
       with:
-          path: ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/dependencies.gradle') }}
+        path: ~/.gradle/caches/modules-2
+        key: ${{ runner.os }}-gradlemodules-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlemodules-
+
+    - name: Cache gradle jars
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches/jars-3
+        key: ${{ runner.os }}-gradlejars-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlejars-
+
+    - name: Cache gradle build
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches/build-cache-1
+        key: ${{ runner.os }}-gradlebuildcache-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlebuildcache-
 
     - name: Download gradle dependencies
       run: ./gradlew dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,32 @@ jobs:
     - name: Copy CI gradle.properties
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-    - uses: actions/cache@v1
+    - name: Generate cache key
+      run: ./.github/checksum.sh checksum.txt
+
+    - name: Cache gradle modules
+      uses: actions/cache@v1
       with:
-          path: ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/dependencies.gradle') }}
+        path: ~/.gradle/caches/modules-2
+        key: ${{ runner.os }}-gradlemodules-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlemodules-
+
+    - name: Cache gradle jars
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches/jars-3
+        key: ${{ runner.os }}-gradlejars-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlejars-
+
+    - name: Cache gradle build
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches/build-cache-1
+        key: ${{ runner.os }}-gradlebuildcache-${{ hashFiles('checksum.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradlebuildcache-
 
     - name: Run unit tests
       run: ./gradlew spotlessCheck test${{ matrix.variant }} lint${{ matrix.variant}} -Dpre-dex=false

--- a/.github/workflows/validate_wrapper.yml
+++ b/.github/workflows/validate_wrapper.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: pull_request
+
+jobs:
+  validation:
+    name: "Wrapper validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
There have been a few instances where our cache has gone over 2GB and simply failed to be used,
or taken very long to extract and become pointless in terms of build time savings. This splits
all cache steps from caching `~/.gradle/caches/` to caching the `modules-2`, `jars-3` and `build-cache-1`
subdirectories separately. This keeps us below the limit and skirts the problem of unpacks taking too long.

Also included is Gradle's official wrapper validation action that will ensure PRs updating the Gradle wrapper
are using the official wrapper and not a modified, potentially compromised version.

## :bulb: Motivation and Context


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
