### PR TITLE
Confirm password move if it will replace an existing one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Allow user to abort password move when it is replacing an existing file
+
 ## [1.7.2] - 2020-04-29
 
 ### Added
@@ -126,7 +129,8 @@ All notable changes to this project will be documented in this file.
 - Fix elements overlapping.
 
 
-[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.2...HEAD
+[1.7.2]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.1..v1.7.2
 [1.7.1]: https://github.com/android-password-store/Android-Password-Store/compare/v1.7.0..v1.7.1
 [1.7.0]: https://github.com/android-password-store/Android-Password-Store/compare/v1.6.0..v1.7.0
 [1.6.0]: https://github.com/android-password-store/Android-Password-Store/compare/v1.5.0..v1.6.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
There was a warning dialog previously added for this scenario but it served no
purpose as it just went ahead and did the replace anyway. This changes it to respect
the user's choice and allow not continuing the operation. I am personally not very happy
with how the password move flow is right now so maybe the next step here is to completely
refactor that.

## :bulb: Motivation and Context
Fixes #451

## :green_heart: How did you test it?
Try to move a password into the same directory it belongs to and get a warning dialog, which
aborts the move operation if you press 'Cancel' and goes ahead with it when 'OK' is selected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
