### PR TITLE
github: implement path filtering to run actions only when required

### DIFF
--- a/.github/workflows/branch_deploy.yml
+++ b/.github/workflows/branch_deploy.yml
@@ -8,6 +8,8 @@ on:
       - 'gradle/**'
       - '*.properties'
       - '*.gradle'
+      - 'gradlew'
+      - 'gradlew.bat'
 
 name: Build debug
 jobs:

--- a/.github/workflows/branch_deploy.yml
+++ b/.github/workflows/branch_deploy.yml
@@ -2,6 +2,12 @@ on:
   push:
     branches-ignore:
       - master
+    paths:
+      - '.github/**'
+      - 'app/**'
+      - 'gradle/**'
+      - '*.properties'
+      - '*.gradle'
 
 name: Build debug
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,8 @@ on:
       - 'gradle/**'
       - '*.properties'
       - '*.gradle'
+      - 'gradlew'
+      - 'gradlew.bat'
 
 name: Check pull request
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,11 @@
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'app/**'
+      - 'gradle/**'
+      - '*.properties'
+      - '*.gradle'
 
 name: Check pull request
 jobs:

--- a/.github/workflows/validate_wrapper.yml
+++ b/.github/workflows/validate_wrapper.yml
@@ -1,5 +1,9 @@
 name: "Validate Gradle Wrapper"
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'gradle/**'
 
 jobs:
   validation:

--- a/.github/workflows/validate_wrapper.yml
+++ b/.github/workflows/validate_wrapper.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - '.github/**'
       - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
 
 jobs:
   validation:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Add the [`paths`](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#filtering-for-specific-branches-tags-and-paths) filter to only run workflows when files that affect them are changed. This will prevent unnecessary waiting for things like README updates.

## :bulb: Motivation and Context


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
