### PR TITLE
PasswordEntry: add more potential fields for username

### DIFF
--- a/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.kt
@@ -42,6 +42,9 @@ class PasswordEntryTest {
                 PasswordEntry("\nextra\nusername: username\ncontent\n").username)
         assertEquals(
                 "username", PasswordEntry("\nUSERNaMe:  username\ncontent\n").username)
+        assertEquals("username", PasswordEntry("\nlogin:    username").username)
+        assertEquals("foo@example.com", PasswordEntry("\nemail: foo@example.com").username)
+        assertEquals("username", PasswordEntry("\nidentity: username\nlogin: another_username").username)
         assertEquals("username", PasswordEntry("\nLOGiN:username").username)
         assertNull(PasswordEntry("secret\nextra\ncontent\n").username)
     }

--- a/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.kt
@@ -34,6 +34,10 @@ class PasswordEntryTest {
     }
 
     @Test fun testGetUsername() {
+        for (field in PasswordEntry.USERNAME_FIELDS) {
+            assertEquals("username", PasswordEntry("\n$field username").username)
+            assertEquals("username", PasswordEntry("\n${field.toUpperCase()} username").username)
+        }
         assertEquals(
                 "username",
                 PasswordEntry("secret\nextra\nlogin: username\ncontent\n").username)

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
@@ -5,6 +5,8 @@
 package com.zeapo.pwdstore
 
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
 import java.io.ByteArrayOutputStream
 import java.io.UnsupportedEncodingException
 
@@ -162,7 +164,8 @@ class PasswordEntry(private val content: String) {
     }
 
     companion object {
-        private val USERNAME_FIELDS = arrayOf(
+        @VisibleForTesting(otherwise = PRIVATE)
+        val USERNAME_FIELDS = arrayOf(
                 "login:",
                 "username:",
                 "account:",

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
@@ -162,7 +162,15 @@ class PasswordEntry(private val content: String) {
     }
 
     companion object {
-
-        private val USERNAME_FIELDS = arrayOf("login:", "username:")
+        private val USERNAME_FIELDS = arrayOf(
+                "login:",
+                "username:",
+                "account:",
+                "email:",
+                "name:",
+                "handle:",
+                "id:",
+                "identity:"
+        )
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
People use a variety of field names for username, and we only really account for two. This expands the list to add more common variants.

## :bulb: Motivation and Context
Fixes #761

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
