### PR TITLE
PasswordEntry: add user to the potential candidates for username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Allow user to abort password move when it is replacing an existing file
 
+### Fixed
+- Add the following fields to encrypted username detection: user, account, email, name, handle, id, identity.
+
 ## [1.7.2] - 2020-04-29
 
 ### Added

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordEntry.kt
@@ -168,6 +168,7 @@ class PasswordEntry(private val content: String) {
         val USERNAME_FIELDS = arrayOf(
                 "login:",
                 "username:",
+                "user:",
                 "account:",
                 "email:",
                 "name:",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds the user label to potential username fields, and also update the changelog.

## :bulb: Motivation and Context
https://github.com/android-password-store/Android-Password-Store/pull/764#discussion_r420476439

## :green_heart: How did you test it?
`PasswordEntryTest` still passes

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
