### PR TITLE
Introduce no-auth mode for connections

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -53,6 +53,7 @@ import com.zeapo.pwdstore.git.GitAsyncTask
 import com.zeapo.pwdstore.git.GitOperation
 import com.zeapo.pwdstore.git.GitOperationActivity
 import com.zeapo.pwdstore.git.GitServerConfigActivity
+import com.zeapo.pwdstore.git.config.ConnectionMode
 import com.zeapo.pwdstore.ui.dialogs.FolderCreationDialogFragment
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
@@ -201,7 +202,13 @@ class PasswordStore : AppCompatActivity() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(if (PasswordRepository.isGitRepo()) R.menu.main_menu_git else R.menu.main_menu_non_git, menu)
+        val menuRes = when {
+            ConnectionMode.fromString(settings.getString("git_remote_auth", null))
+                    == ConnectionMode.None -> R.menu.main_menu_no_auth
+            PasswordRepository.isGitRepo() -> R.menu.main_menu_git
+            else -> R.menu.main_menu_non_git
+        }
+        menuInflater.inflate(menuRes, menu)
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
@@ -247,6 +247,9 @@ abstract class GitOperation(fileDir: File, internal val callingActivity: Activit
                     dialog.show()
                 }
             }
+            ConnectionMode.None -> {
+                execute()
+            }
         }
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/ConnectionMode.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/ConnectionMode.kt
@@ -7,7 +7,9 @@ package com.zeapo.pwdstore.git.config
 enum class ConnectionMode(val pref: String) {
     SshKey("ssh-key"),
     Password("username/password"),
-    OpenKeychain("OpenKeychain");
+    OpenKeychain("OpenKeychain"),
+    None("None"),
+    ;
 
     companion object {
         private val map = values().associateBy(ConnectionMode::pref)

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/Protocol.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/Protocol.kt
@@ -6,7 +6,8 @@ package com.zeapo.pwdstore.git.config
 
 enum class Protocol(val pref: String) {
     Ssh("ssh://"),
-    Https("https://");
+    Https("https://"),
+    ;
 
     companion object {
         private val map = values().associateBy(Protocol::pref)

--- a/app/src/main/res/drawable/ic_refresh_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_refresh_white_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="#FFFFFFFF"
-      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
-</vector>

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -156,50 +156,39 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/label_server_path" />
 
-        <com.google.android.material.button.MaterialButtonToggleGroup
+        <RadioGroup
             android:id="@+id/connection_mode_group"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
+            android:orientation="vertical"
             app:layout_constraintTop_toBottomOf="@id/label_connection_mode"
-            app:layout_constraintStart_toStartOf="parent"
-            app:selectionRequired="true"
-            app:singleSelection="true" >
+            app:layout_constraintStart_toStartOf="parent">
 
-            <com.google.android.material.button.MaterialButton
-                style="?attr/materialButtonOutlinedStyle"
+            <RadioButton
                 android:id="@+id/connection_mode_ssh_key"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/connection_mode_ssh_key"
-                android:textColor="?android:attr/textColorPrimary"
-                app:rippleColor="@color/ripple_color"
-                app:strokeColor="?attr/colorSecondary"
-                app:backgroundTint="@color/toggle_button_selector" />
+                android:text="@string/connection_mode_ssh_key" />
 
-            <com.google.android.material.button.MaterialButton
-                style="?attr/materialButtonOutlinedStyle"
+            <RadioButton
                 android:id="@+id/connection_mode_password"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/connection_mode_basic_authentication"
-                android:textColor="?android:attr/textColorPrimary"
-                app:rippleColor="@color/ripple_color"
-                app:strokeColor="?attr/colorSecondary"
-                app:backgroundTint="@color/toggle_button_selector" />
+                android:text="@string/connection_mode_basic_authentication" />
 
-            <com.google.android.material.button.MaterialButton
-                style="?attr/materialButtonOutlinedStyle"
+            <RadioButton
                 android:id="@+id/connection_mode_open_keychain"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/connection_mode_openkeychain"
-                android:textColor="?android:attr/textColorPrimary"
-                app:rippleColor="@color/ripple_color"
-                app:strokeColor="?attr/colorSecondary"
-                app:backgroundTint="@color/toggle_button_selector" />
+                android:text="@string/connection_mode_openkeychain" />
 
-        </com.google.android.material.button.MaterialButtonToggleGroup>
+            <RadioButton
+                android:id="@+id/connection_mode_none"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/connection_mode_none" />
+
+        </RadioGroup>
 
         <com.google.android.material.button.MaterialButton
             style="@style/Widget.MaterialComponents.Button"

--- a/app/src/main/res/menu/main_menu_git.xml
+++ b/app/src/main/res/menu/main_menu_git.xml
@@ -17,9 +17,7 @@
         android:title="@string/git_push"/>
 
     <item android:id="@+id/refresh"
-        android:title="@string/refresh_list"
-        android:icon="@drawable/ic_refresh_white_24dp"
-        app:showAsAction="never"/>
+        android:title="@string/refresh_list" />
 
     <item android:id="@+id/user_pref"
         android:title="@string/action_settings"

--- a/app/src/main/res/menu/main_menu_no_auth.xml
+++ b/app/src/main/res/menu/main_menu_no_auth.xml
@@ -9,6 +9,9 @@
         app:showAsAction="always|collapseActionView"
         app:actionViewClass="androidx.appcompat.widget.SearchView" />
 
+    <item android:id="@+id/git_pull"
+        android:title="@string/git_pull"/>
+
     <item android:id="@+id/refresh"
         android:title="@string/refresh_list" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,9 +354,10 @@
     <string name="theme_follow_system">System default</string>
     <string name="clone_protocol_ssh" translatable="false">SSH</string>
     <string name="clone_protocol_https" translatable="false">HTTPS</string>
-    <string name="connection_mode_ssh_key" translatable="false">SSH key</string>
-    <string name="connection_mode_basic_authentication" translatable="false">Password</string>
+    <string name="connection_mode_ssh_key">SSH key</string>
+    <string name="connection_mode_basic_authentication">Password</string>
     <string name="connection_mode_openkeychain" translatable="false">OpenKeychain</string>
+    <string name="connection_mode_none">None</string>
     <string name="git_server_config_save_success">Successfully saved configuration</string>
     <string name="git_server_config_save_failure">Configuration error: please verify your settings and try again</string>
     <string name="git_operation_unable_to_open_ssh_key_title">Unable to open the ssh-key</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Introduces a new authentication mode, 'None', to deal with the particular case of cloning from publicly accessible
repositories which do not need to be pushed to. To achieve this, the following changes were made:

- New `main_menu_no_auth` variant for overflow menu that only has a pull option
- Plumbing in `GitOperation` to directly execute the command provided
- Code cleanup and logic tweaks in `GitServerConfigActivity` to handle the new option
- UI change from `MaterialButtonToggleGroup` to `RadioGroup` for connection mode to adjust for
  being unable to fit another button.

## :bulb: Motivation and Context
Fixes #758

## :green_heart: How did you test it?
Clone a public GitHub repository with no authentication set and was successfully able to do so.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
