### PR TITLE
Make connection mode a <= 1 toggle group to prevent UI overflow

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -6,6 +6,7 @@ package com.zeapo.pwdstore.git
 
 import android.os.Bundle
 import android.os.Handler
+import android.view.View
 import androidx.core.content.edit
 import androidx.core.os.postDelayed
 import androidx.core.widget.doOnTextChanged
@@ -50,18 +51,20 @@ class GitServerConfigActivity : BaseGitActivity() {
             }
         }
 
-        binding.connectionModeGroup.check(when (connectionMode) {
-            ConnectionMode.SshKey -> R.id.connection_mode_ssh_key
-            ConnectionMode.Password -> R.id.connection_mode_password
-            ConnectionMode.OpenKeychain -> R.id.connection_mode_open_keychain
-            ConnectionMode.None -> R.id.connection_mode_none
-        })
-        binding.connectionModeGroup.setOnCheckedChangeListener { group, _ ->
-            when (group.checkedRadioButtonId) {
-                R.id.connection_mode_ssh_key -> connectionMode = ConnectionMode.SshKey
-                R.id.connection_mode_open_keychain -> connectionMode = ConnectionMode.OpenKeychain
-                R.id.connection_mode_password -> connectionMode = ConnectionMode.Password
-                R.id.connection_mode_none -> connectionMode = ConnectionMode.None
+        binding.connectionModeGroup.apply {
+            when (connectionMode) {
+                ConnectionMode.SshKey -> check(R.id.connection_mode_ssh_key)
+                ConnectionMode.Password -> check(R.id.connection_mode_password)
+                ConnectionMode.OpenKeychain -> check(R.id.connection_mode_open_keychain)
+                ConnectionMode.None -> uncheck(checkedButtonId)
+            }
+            addOnButtonCheckedListener { group, _, _ ->
+                when (checkedButtonId) {
+                    R.id.connection_mode_ssh_key -> connectionMode = ConnectionMode.SshKey
+                    R.id.connection_mode_open_keychain -> connectionMode = ConnectionMode.OpenKeychain
+                    R.id.connection_mode_password -> connectionMode = ConnectionMode.Password
+                    View.NO_ID -> connectionMode = ConnectionMode.None
+                }
             }
         }
         updateConnectionModeToggleGroup()
@@ -119,12 +122,14 @@ class GitServerConfigActivity : BaseGitActivity() {
 
     private fun updateConnectionModeToggleGroup() {
         if (protocol == Protocol.Ssh) {
-            if (binding.connectionModeNone.isChecked)
+            // Reset connection mode to SSH key if the current value (none) is not valid for SSH
+            if (binding.connectionModeGroup.checkedButtonIds.isEmpty())
                 binding.connectionModeGroup.check(R.id.connection_mode_ssh_key)
             binding.connectionModeSshKey.isEnabled = true
             binding.connectionModeOpenKeychain.isEnabled = true
-            binding.connectionModeNone.isEnabled = false
+            binding.connectionModeGroup.isSelectionRequired = true
         } else {
+            binding.connectionModeGroup.isSelectionRequired = false
             // Reset connection mode to password if the current value is not valid for HTTPS
             // Important note: This has to happen before disabling the other toggle buttons or they
             // won't uncheck.
@@ -132,7 +137,6 @@ class GitServerConfigActivity : BaseGitActivity() {
                 binding.connectionModeGroup.check(R.id.connection_mode_password)
             binding.connectionModeSshKey.isEnabled = false
             binding.connectionModeOpenKeychain.isEnabled = false
-            binding.connectionModeNone.isEnabled = true
         }
     }
 

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -145,43 +145,37 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/label_server_path" />
 
-        <RadioGroup
+        <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/connection_mode_group"
+            style="@style/TextAppearance.MaterialComponents.Headline1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
+            android:layout_margin="8dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_connection_mode">
+            app:layout_constraintTop_toBottomOf="@id/label_connection_mode"
+            app:singleSelection="true">
 
-            <RadioButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/connection_mode_ssh_key"
+                style="?attr/materialButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:padding="4dp"
                 android:text="@string/connection_mode_ssh_key" />
 
-            <RadioButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/connection_mode_password"
+                style="?attr/materialButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:padding="4dp"
                 android:text="@string/connection_mode_basic_authentication" />
 
-            <RadioButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/connection_mode_open_keychain"
+                style="?attr/materialButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:padding="4dp"
                 android:text="@string/connection_mode_openkeychain" />
-
-            <RadioButton
-                android:id="@+id/connection_mode_none"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="4dp"
-                android:text="@string/connection_mode_none" />
-
-        </RadioGroup>
+        </com.google.android.material.button.MaterialButtonToggleGroup>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/save_button"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Replace the connection mode RadioGroup in GitServerConfigActivity with a MaterialButtonToggleGroup again, but don't always make it selectionRequired.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the connection modes arranged in a RadioGroup, we get UI issues on phones that are not wide enough. This is not easily fixed since RadioGroup inherits from LinearLayout.

<details><summary>Screenshot</summary>
<img src=https://user-images.githubusercontent.com/4312191/81900999-2547aa80-95be-11ea-86c9-3d2bead21258.jpg>
</details>

## :green_heart: How did you test it?
I pressed some buttons and confirmed that the modes are also saved correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps
Decide whether we want this slightly less discoverable (but arguably more logical and more space-efficient) UI representation.

## :camera_flash: Screenshots / GIFs
<details><summary>Screenshot</summary>
<img src=https://user-images.githubusercontent.com/4312191/81901294-97b88a80-95be-11ea-986e-97b225decf95.jpg>
<img src=https://user-images.githubusercontent.com/4312191/81901297-98512100-95be-11ea-8ef9-45dae08843f7.jpg>
</details>
