### PR TITLE
Improve Git/HTTPS URL generation

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -97,22 +97,23 @@ class GitServerConfigActivity : BaseGitActivity() {
         binding.saveButton.setOnClickListener {
             if (isClone && PasswordRepository.getRepository(null) == null)
                 PasswordRepository.initialize(this)
-            if (updateUrl()) {
-                settings.edit {
-                    putString("git_remote_protocol", protocol.pref)
-                    putString("git_remote_auth", connectionMode.pref)
-                    putString("git_remote_server", serverHostname)
-                    putString("git_remote_port", serverPort)
-                    putString("git_remote_username", serverUser)
-                    putString("git_remote_location", serverPath)
+            when (val result = updateUrl()) {
+                GitUpdateUrlResult.Ok -> {
+                    settings.edit {
+                        putString("git_remote_protocol", protocol.pref)
+                        putString("git_remote_auth", connectionMode.pref)
+                        putString("git_remote_server", serverHostname)
+                        putString("git_remote_port", serverPort)
+                        putString("git_remote_username", serverUser)
+                        putString("git_remote_location", serverPath)
+                    }
+                    if (!isClone) {
+                        Snackbar.make(binding.root, getString(R.string.git_server_config_save_success), Snackbar.LENGTH_SHORT).show()
+                        Handler().postDelayed(500) { finish() }
+                    } else
+                        cloneRepository()
                 }
-                if (!isClone) {
-                    Snackbar.make(binding.root, getString(R.string.git_server_config_save_success), Snackbar.LENGTH_SHORT).show()
-                    Handler().postDelayed(500) { finish() }
-                } else
-                    cloneRepository()
-            } else {
-                Snackbar.make(binding.root, getString(R.string.git_server_config_save_failure), Snackbar.LENGTH_LONG).show()
+                else -> Snackbar.make(binding.root, getString(R.string.git_server_config_save_error_prefix, getString(result.textRes)), Snackbar.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,7 +363,11 @@
     <string name="connection_mode_openkeychain" translatable="false">OpenKeychain</string>
     <string name="connection_mode_none">None</string>
     <string name="git_server_config_save_success">Successfully saved configuration</string>
-    <string name="git_server_config_save_failure">Configuration error: please verify your settings and try again</string>
+    <string name="git_server_config_save_error_prefix">Configuration error: %s</string>
+    <string name="git_config_error_hostname_empty">empty hostname</string>
+    <string name="git_config_error_generic">please verify your settings and try again</string>
+    <string name="git_config_error_nonnumeric_port">port must be numeric</string>
+    <string name="git_config_error_custom_port_absolute">path must be absolute (start with \'/\') when using a custom port</string>
     <string name="git_operation_unable_to_open_ssh_key_title">Unable to open the ssh-key</string>
     <string name="git_operation_unable_to_open_ssh_key_message">Please check that it was imported.</string>
     <string name="git_operation_wrong_passphrase">Wrong passphrase</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Improve the generation of the Git/HTTPS repo URL from its parts in multiple ways:

* Strip the "ssh://" prefix if somebody entered it
* Use the ssh:// scheme if there is a custom port
* Apply the URI verification only to HTTPS
* Trim trailing @s from the user part

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix #777.

## :green_heart: How did you test it?
I tried some variations, but have not been able to test HTTPS and SSH with custom ports. Please do if you can.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
