### PR TITLE
treewide: correct misspellings

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
@@ -68,7 +68,7 @@ class CloneOperation(fileDir: File, callingActivity: Activity) : GitOperation(fi
         super.onError(errorMessage)
         MaterialAlertDialogBuilder(callingActivity)
             .setTitle(callingActivity.resources.getString(R.string.jgit_error_dialog_title))
-            .setMessage("Error occured during the clone operation, " +
+            .setMessage("Error occurred during the clone operation, " +
                 callingActivity.resources.getString(R.string.jgit_error_dialog_text) +
                 errorMessage +
                 "\nPlease check the FAQ for possible reasons why this error might occur.")

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
@@ -42,7 +42,7 @@ class PullOperation(fileDir: File, callingActivity: Activity) : GitOperation(fil
         super.onError(errorMessage)
         MaterialAlertDialogBuilder(callingActivity)
             .setTitle(callingActivity.resources.getString(R.string.jgit_error_dialog_title))
-            .setMessage("Error occured during the pull operation, " +
+            .setMessage("Error occurred during the pull operation, " +
                 callingActivity.resources.getString(R.string.jgit_error_dialog_text) +
                 errorMessage +
                 "\nPlease check the FAQ for possible reasons why this error might occur.")

--- a/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
@@ -49,7 +49,7 @@ class ResetToRemoteOperation(fileDir: File, callingActivity: Activity) : GitOper
         super.onError(errorMessage)
         MaterialAlertDialogBuilder(callingActivity)
             .setTitle(callingActivity.resources.getString(R.string.jgit_error_dialog_title))
-            .setMessage("Error occured during the sync operation, " +
+            .setMessage("Error occurred during the sync operation, " +
                 "\nPlease check the FAQ for possible reasons why this error might occur." +
                 callingActivity.resources.getString(R.string.jgit_error_dialog_text) +
                 errorMessage)

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
@@ -57,7 +57,7 @@ class SyncOperation(fileDir: File, callingActivity: Activity) : GitOperation(fil
         super.onError(errorMessage)
         MaterialAlertDialogBuilder(callingActivity)
             .setTitle(callingActivity.resources.getString(R.string.jgit_error_dialog_title))
-            .setMessage("Error occured during the sync operation, " +
+            .setMessage("Error occurred during the sync operation, " +
                 "\nPlease check the FAQ for possible reasons why this error might occur." +
                 callingActivity.resources.getString(R.string.jgit_error_dialog_text) +
                 errorMessage)

--- a/app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt
@@ -7,44 +7,44 @@ package com.zeapo.pwdstore.pwgen
 internal object Phonemes {
     private const val CONSONANT = 0x0001
     private const val VOWEL = 0x0002
-    private const val DIPTHONG = 0x0004
+    private const val DIPHTHONG = 0x0004
     private const val NOT_FIRST = 0x0008
 
     private val elements = arrayOf(
         Element("a", VOWEL),
-        Element("ae", VOWEL or DIPTHONG),
-        Element("ah", VOWEL or DIPTHONG),
-        Element("ai", VOWEL or DIPTHONG),
+        Element("ae", VOWEL or DIPHTHONG),
+        Element("ah", VOWEL or DIPHTHONG),
+        Element("ai", VOWEL or DIPHTHONG),
         Element("b", CONSONANT),
         Element("c", CONSONANT),
-        Element("ch", CONSONANT or DIPTHONG),
+        Element("ch", CONSONANT or DIPHTHONG),
         Element("d", CONSONANT),
         Element("e", VOWEL),
-        Element("ee", VOWEL or DIPTHONG),
-        Element("ei", VOWEL or DIPTHONG),
+        Element("ee", VOWEL or DIPHTHONG),
+        Element("ei", VOWEL or DIPHTHONG),
         Element("f", CONSONANT),
         Element("g", CONSONANT),
-        Element("gh", CONSONANT or DIPTHONG or NOT_FIRST),
+        Element("gh", CONSONANT or DIPHTHONG or NOT_FIRST),
         Element("h", CONSONANT),
         Element("i", VOWEL),
-        Element("ie", VOWEL or DIPTHONG),
+        Element("ie", VOWEL or DIPHTHONG),
         Element("j", CONSONANT),
         Element("k", CONSONANT),
         Element("l", CONSONANT),
         Element("m", CONSONANT),
         Element("n", CONSONANT),
-        Element("ng", CONSONANT or DIPTHONG or NOT_FIRST),
+        Element("ng", CONSONANT or DIPHTHONG or NOT_FIRST),
         Element("o", VOWEL),
-        Element("oh", VOWEL or DIPTHONG),
-        Element("oo", VOWEL or DIPTHONG),
+        Element("oh", VOWEL or DIPHTHONG),
+        Element("oo", VOWEL or DIPHTHONG),
         Element("p", CONSONANT),
-        Element("ph", CONSONANT or DIPTHONG),
-        Element("qu", CONSONANT or DIPTHONG),
+        Element("ph", CONSONANT or DIPHTHONG),
+        Element("qu", CONSONANT or DIPHTHONG),
         Element("r", CONSONANT),
         Element("s", CONSONANT),
-        Element("sh", CONSONANT or DIPTHONG),
+        Element("sh", CONSONANT or DIPHTHONG),
         Element("t", CONSONANT),
-        Element("th", CONSONANT or DIPTHONG),
+        Element("th", CONSONANT or DIPHTHONG),
         Element("u", VOWEL),
         Element("v", CONSONANT),
         Element("w", CONSONANT),
@@ -108,9 +108,9 @@ internal object Phonemes {
                 if (first && flags and NOT_FIRST > 0) {
                     continue
                 }
-                // Don't allow VOWEL followed a Vowel/Dipthong pair
+                // Don't allow VOWEL followed a Vowel/Diphthong pair
                 if (prev and VOWEL > 0 && flags and VOWEL > 0 &&
-                    flags and DIPTHONG > 0
+                    flags and DIPHTHONG > 0
                 ) {
                     continue
                 }
@@ -204,7 +204,7 @@ internal object Phonemes {
                 shouldBe = if (shouldBe == CONSONANT) {
                     VOWEL
                 } else {
-                    if (prev and VOWEL > 0 || flags and DIPTHONG > 0 ||
+                    if (prev and VOWEL > 0 || flags and DIPHTHONG > 0 ||
                         RandomNumberGenerator.number(10) > 3
                     ) {
                         CONSONANT


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Makes the following corrections using https://github.com/client9/misspell

```
app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt:71:31: corrected "occured" to "occurred"
app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt:45:31: corrected "occured" to "occurred"
app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt:60:31: corrected "occured" to "occurred"
app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt:52:31: corrected "occured" to "occurred"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:10:22: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:15:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:16:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:17:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:20:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:23:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:24:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:27:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:30:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:36:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:38:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:39:31: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:41:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:42:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:45:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:47:35: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:111:54: corrected "Dipthong" to "Diphthong"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:113:30: corrected "DIPTHONG" to "DIPHTHONG"
app/src/main/java/com/zeapo/pwdstore/pwgen/Phonemes.kt:207:56: corrected "DIPTHONG" to "DIPHTHONG"
```

## :bulb: Motivation and Context
¯\_(ツ)_/¯

## :green_heart: How did you test it?
¯\_(ツ)_/¯

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
