### PR TITLE
BaseGitActivity: always enforce absolute URLs

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -113,9 +113,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 val portPart =
                     if (serverPort == "22" || serverPort.isEmpty()) "" else ":$serverPort"
                 if (portPart.isEmpty()) {
-                    // We only support relative paths with the standard port.
-                    val pathPart = serverPath.trimStart('/', ':')
-                    "$userPart$hostnamePart:$pathPart"
+                    "$userPart$hostnamePart:$serverPath"
                 } else {
                     // Only absolute paths are supported with custom ports.
                     if (!serverPath.startsWith('/'))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Always enforce leading slash since relative URLs are not always correct.

## :bulb: Motivation and Context
An example of the case that should work but doesn't is `/mnt/foo/pass-repo` with default SSH port will have the leading `/` resulting in the path becoming `mnt/foo/pass-repo` that gets resolved as relative from `$HOME` which is obviously wrong.

## :green_heart: How did you test it?
Tested manually with the following configuration

- custom port, path in `$HOME`
- default port, path in `$HOME`
- custom port, path in `/mnt/`
- default port, path in `/mnt/`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps
T E S T S!


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
