### PR TITLE
Remove "name" from the list of username heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Reduce Autofill false positives on username fields by removing "name" from list of heuristic terms
+
 ## [1.8.1] - 2020-05-24
 
 ### Fixed

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
@@ -83,7 +83,7 @@ class FormField(
             "pass", "pswd", "pwd"
         )
         private val USERNAME_HEURISTIC_TERMS = listOf(
-            "alias", "e-mail", "email", "login", "name", "user"
+            "alias", "e-mail", "email", "login", "user"
         )
     }
 


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Remove "name" from the list of resource id/HTML attribute heuristic terms for username fields.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It causes far too many false positives in non-login forms.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
