### PR TITLE
treewide: update fragments to use LayoutRes constructor

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -36,7 +36,7 @@ import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import java.io.File
 import java.util.Stack
 
-class PasswordFragment : Fragment() {
+class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     private lateinit var recyclerAdapter: PasswordItemRecyclerAdapter
     private lateinit var listener: OnFragmentInteractionListener
     private lateinit var settings: SharedPreferences

--- a/app/src/main/java/com/zeapo/pwdstore/SelectFolderFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SelectFolderFragment.kt
@@ -19,7 +19,7 @@ import com.zeapo.pwdstore.utils.viewBinding
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import java.io.File
 
-class SelectFolderFragment : Fragment() {
+class SelectFolderFragment : Fragment(R.layout.password_recycler_view) {
     private val binding by viewBinding(PasswordRecyclerViewBinding::bind)
     private lateinit var recyclerAdapter: PasswordItemRecyclerAdapter
     private lateinit var listener: OnFragmentInteractionListener

--- a/app/src/main/java/com/zeapo/pwdstore/ToCloneOrNot.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ToCloneOrNot.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.Fragment
 import com.zeapo.pwdstore.databinding.FragmentToCloneOrNotBinding
 import com.zeapo.pwdstore.utils.viewBinding
 
-class ToCloneOrNot : Fragment() {
+class ToCloneOrNot : Fragment(R.layout.fragment_to_clone_or_not) {
 
     private val binding by viewBinding(FragmentToCloneOrNotBinding::bind)
 

--- a/app/src/main/java/com/zeapo/pwdstore/sshkeygen/SshKeyGenFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/sshkeygen/SshKeyGenFragment.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
-class SshKeyGenFragment : Fragment() {
+class SshKeyGenFragment : Fragment(R.layout.fragment_ssh_keygen) {
 
     private var keyLength = 4096
     private val binding by viewBinding(FragmentSshKeygenBinding::bind)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
When I removed the `onCreateView` overrides in #799, I moved the view creation repsonsibility from us to no-one, which broke the app in a myriad of ways. This PR changes that from no-one to the fragment library.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`master` currently has no UI

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps
More tests for the app and less drugs for me.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
