### PR TITLE
Configure IME options and focus direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Reduce Autofill false positives on username fields by removing "name" from list of heuristic terms
 - Reduced app size
+- Improve IME experience with server config screen
 
 ## [1.8.1] - 2020-05-24
 

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -10,6 +10,7 @@
     android:layout_height="match_parent"
     android:background="?android:attr/windowBackground"
     android:padding="@dimen/activity_horizontal_margin"
+    tools:background="@color/white"
     tools:context="com.zeapo.pwdstore.git.GitOperationActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -76,7 +77,12 @@
                 android:id="@+id/server_user"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textWebEmailAddress" />
+                android:imeOptions="actionNext"
+                android:inputType="textWebEmailAddress"
+                android:nextFocusForward="@id/server_url">
+
+                <requestFocus />
+            </com.google.android.material.textfield.TextInputEditText>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -93,7 +99,9 @@
                 android:id="@+id/server_url"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textWebEmailAddress" />
+                android:imeOptions="actionNext"
+                android:inputType="textWebEmailAddress"
+                android:nextFocusForward="@id/server_port" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -112,7 +120,9 @@
                 android:id="@+id/server_port"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number" />
+                android:imeOptions="actionNext"
+                android:inputType="number"
+                android:nextFocusForward="@id/server_path" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -129,6 +139,7 @@
                 android:id="@+id/server_path"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
                 android:inputType="textWebEmailAddress" />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Configure `nextFocusForward` and `imeOptions` to correctly navigate IME enter key across the server config UI

## :bulb: Motivation and Context
Before this change pressing the IME enter button would take you from username -> server url -> repo path, now it's something like this: username -> server url -> port -> repo path -> ime closes on each press of the enter button.

## :green_heart: How did you test it?
Recorded a beautiful GIF for you!

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
![nice_flow](https://user-images.githubusercontent.com/13348378/83132274-c5451e00-a0fe-11ea-8dd3-d23099e27ec2.gif)
