### PR TITLE
Completely revamp decrypted password screen

### DIFF
--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -68,137 +68,68 @@
             app:layout_constraintTop_toBottomOf="@id/crypto_password_last_changed"
             tools:ignore="ContentDescription" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/crypto_container_decrypt"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_text_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_vertical_margin"
-            android:visibility="invisible"
+            android:layout_marginTop="16dp"
+            android:hint="@string/password"
+            android:visibility="gone"
+            app:endIconMode="password_toggle"
             app:layout_constraintTop_toBottomOf="@id/divider"
             tools:visibility="visible">
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_password_show_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/password"
-                android:textColor="?android:attr/textColor"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_password_show"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="fill"
-                android:gravity="bottom"
-                android:textColor="?android:attr/textColor"
-                android:typeface="monospace"
-                app:layout_constraintBaseline_toBaselineOf="@id/crypto_password_show_label"
-                app:layout_constraintStart_toEndOf="@id/crypto_password_show_label" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/crypto_password_toggle_show"
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/show_password"
-                app:layout_constraintTop_toBottomOf="@id/crypto_password_show_label" />
+                android:editable="false"
+                android:fontFamily="@font/sourcecodepro"
+                android:textIsSelectable="true"
+                tools:text="p@55w0rd!" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/crypto_extra_show_layout"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/username_text_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="invisible"
-            app:layout_constraintTop_toBottomOf="@id/crypto_container_decrypt"
+            android:layout_marginTop="16dp"
+            android:hint="@string/username"
+            android:visibility="gone"
+            app:endIconDrawable="@drawable/ic_content_copy"
+            app:endIconMode="custom"
+            app:layout_constraintTop_toBottomOf="@id/password_text_container"
             tools:visibility="visible">
 
-            <androidx.appcompat.widget.AppCompatImageButton
-                android:id="@+id/crypto_copy_username"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:layout_alignParentEnd="true"
-                android:background="?android:attr/windowBackground"
-                android:contentDescription="@string/copy_username"
-                android:src="@drawable/ic_content_copy"
-                android:visibility="invisible"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:visibility="visible" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_username_show_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_alignParentTop="true"
-                android:layout_toStartOf="@id/crypto_copy_username"
-                android:text="@string/username"
-                android:textColor="?android:attr/textColor"
-                android:textStyle="bold"
-                android:visibility="invisible"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:visibility="visible" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_username_show"
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/username_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/crypto_username_show_label"
-                android:layout_alignParentStart="true"
-                android:layout_toStartOf="@id/crypto_copy_username"
-                android:textColor="?android:attr/textColor"
+                android:editable="false"
                 android:textIsSelectable="true"
-                android:typeface="monospace"
-                android:visibility="invisible"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/crypto_username_show_label"
-                tools:visibility="visible" />
+                tools:text="totally_real_user@example.com" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_extra_show_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/crypto_username_show"
-                android:layout_alignParentStart="true"
-                android:text="@string/extra_content"
-                android:textColor="?android:attr/textColor"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/crypto_username_show" />
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/extra_content_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/extra_content"
+            android:visibility="gone"
+            app:endIconMode="password_toggle"
+            app:layout_constraintTop_toBottomOf="@id/username_text_container"
+            tools:visibility="visible">
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/crypto_extra_show"
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/extra_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/crypto_extra_show_label"
-                android:layout_alignParentStart="true"
-                android:textColor="?android:attr/textColor"
+                android:editable="false"
                 android:textIsSelectable="true"
-                android:typeface="monospace"
-                app:layout_constraintTop_toBottomOf="@id/crypto_extra_show_label" />
-
-            <ToggleButton
-                android:id="@+id/crypto_extra_toggle_show"
-                style="@style/Widget.MaterialComponents.Button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/crypto_extra_show"
-                android:layout_alignParentStart="true"
-                android:backgroundTint="?attr/colorSecondary"
-                android:checked="false"
-                android:paddingTop="8dp"
-                android:textColor="?android:attr/windowBackground"
-                android:textOff="@string/show_extra"
-                android:textOn="@string/hide_extra"
-                app:layout_constraintTop_toBottomOf="@id/crypto_extra_show" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                tools:text="lots of extra content that will surely fill this \n up well" />
+        </com.google.android.material.textfield.TextInputLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -16,7 +16,6 @@
     <string name="delete">حذف</string>
     <!-- PGPHandler -->
     <string name="provider_toast_text">لم يتم إختيار مزود الأوبن بي جي بي بعد !</string>
-    <string name="clipboard_username_toast_text">تم نسخ إسم المستخدم إلى الحافظة</string>
     <string name="file_toast_text">الرجاء إدخال إسم ملف</string>
     <!-- Git Async Task -->
     <string name="running_dialog_text">جاري تنفيذ الأمر ...</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -33,7 +33,6 @@
     <string name="provider_toast_text">Nebyl vybrán poskytovatel OpenPGP!</string>
     <string name="clipboard_password_toast_text">Heslo zkopírováno do schránky, máte %d sekund na jeho zkopírování.</string>
     <string name="clipboard_password_no_clear_toast_text">Heslo zkopírováno do schránky</string>
-    <string name="clipboard_username_toast_text">Jméno zkopírováno do schránky</string>
     <string name="file_toast_text">Zadejte prosím jméno souboru</string>
     <string name="path_toast_text">Prosím zadejte cestu k souboru</string>
     <string name="empty_toast_text">Nelze zadat prázdné heslo nebo další obsah</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,7 +20,6 @@
     <!-- PGPHandler -->
     <string name="provider_toast_text">Kein OpenPGP-Provider ausgewählt!</string>
     <string name="clipboard_password_toast_text">Passwort ist in der Zwischenablage, du hast %d Sekunden, um es einzufügen.</string>
-    <string name="clipboard_username_toast_text">Benutzername ist in der Zwischenablage</string>
     <string name="file_toast_text">Bitte setze einen Pfad</string>
     <string name="empty_toast_text">Du kannst kein leeres Passwort setzen oder leere Extra-Angaben</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@
     <string name="provider_toast_text">¡No se ha seleccionado ningún proveedor OpenGPG!</string>
     <string name="clipboard_password_toast_text">Contraseña copiada al portapapeles, tienes %d segundos para pegarla.</string>
     <string name="clipboard_password_no_clear_toast_text">Contraseña copiada al portapapeles</string>
-    <string name="clipboard_username_toast_text">Nombre de usuario copiado al portapapeles</string>
     <string name="file_toast_text">Por favor selecciona un nombre de archivo</string>
     <string name="empty_toast_text">No puedes dejar la contraseña y el contenido extra ambos vacíos</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,7 +35,6 @@
     <!-- PGPHandler -->
     <string name="provider_toast_text">Aucun prestataire OpenPGP sélectionné !</string>
     <string name="clipboard_password_toast_text">Mot de passe copié dans le presse papier, vous avez %d secondes pour coller celui-ci.</string>
-    <string name="clipboard_username_toast_text">Nom d\'utilisateur copié</string>
     <string name="file_toast_text">Renseignez un nom de fichier</string>
     <string name="empty_toast_text">Vous ne pouvez pas utiliser un mot de passe vide ou des données supplémentaires vide</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,7 +36,6 @@
     <string name="provider_toast_text">Не выбран провайдер OpenPGP!</string>
     <string name="clipboard_password_toast_text">Пароль скопирован в буфер обмена, у вас есть %d секунд чтобы вставить его.</string>
     <string name="clipboard_password_no_clear_toast_text">Пароль скопирован в буфер обмена</string>
-    <string name="clipboard_username_toast_text">Имя пользователя скопировано в буфер обмена</string>
     <string name="file_toast_text">Пожалуйста, укажите имя файла</string>
     <string name="path_toast_text">Пожалуйста, задайте путь к файлу</string>
     <string name="empty_toast_text">Вы не можете использовать пустой пароль или пустое поле информации</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="provider_toast_text">No OpenPGP provider selected!</string>
     <string name="clipboard_password_toast_text">Password copied to clipboard, you have %d seconds to paste it somewhere.</string>
     <string name="clipboard_password_no_clear_toast_text">Password copied to clipboard</string>
-    <string name="clipboard_username_toast_text">Username copied to clipboard</string>
+    <string name="clipboard_copied_text">Copied to clipboard</string>
     <string name="file_toast_text">Please provide a file name</string>
     <string name="path_toast_text">Please provide a file path</string>
     <string name="empty_toast_text">You cannot use an empty password or empty extra content</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
Revamps the password UI to use text input fields and fancier end icon toggles. This also greatly reduces the layout nesting improving perf.


## :bulb: Motivation and Context
The decrypt screen UX wasn't really great and was due for a rebirth.

## :green_heart: How did you test it?
Created the GIF below

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
![New UI demo](https://user-images.githubusercontent.com/13348378/83337121-849ffd00-a2d6-11ea-8d20-0ed70207192b.gif)
