### PR TITLE
Fix GitAsyncTask activity handling in error case

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
@@ -131,6 +131,10 @@ class GitAsyncTask(
             is Result.Err -> {
                 e(result.err)
                 operation.onError(rootCauseException(result.err))
+                if (finishWithResultOnEnd != null) {
+                    activity?.setResult(Activity.RESULT_CANCELED)
+                    activity?.finish()
+                }
             }
             is Result.Ok -> {
                 operation.onSuccess()
@@ -138,10 +142,10 @@ class GitAsyncTask(
                     activity?.setResult(Activity.RESULT_OK, finishWithResultOnEnd)
                     activity?.finish()
                 }
-                if (refreshListOnEnd) {
-                    (activity as? PasswordStore)?.resetPasswordList()
-                }
             }
+        }
+        if (refreshListOnEnd) {
+            (activity as? PasswordStore)?.resetPasswordList()
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
GitAsyncTask should finish or refresh the calling activity correctly even if the `onPostExecute` result is an error.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow-up to #815.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
