### PR TITLE
Revert "Stabilize .idea/gradle.xml (#819)"

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>


### PR DESCRIPTION
This reverts commit 8bacbf5ed654f25a55b69d88e94bbe46f80da63f.

Both Android Studio 4.1.x and IntelliJ IDEA 2020.1.1 suggest that I do use this option so we're probably better off _not_ removing it.