### PR TITLE
AccessibilityAutofill: disable the service above Oreo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,7 @@
 
         <service
             android:name=".autofill.AutofillService"
+            android:enabled="@bool/enable_accessibility_autofill"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService" />

--- a/app/src/main/res/values-v23/bools.xml
+++ b/app/src/main/res/values-v23/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_accessibility_autofill">true</bool>
+</resources>

--- a/app/src/main/res/values-v26/bools.xml
+++ b/app/src/main/res/values-v26/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_accessibility_autofill">false</bool>
+</resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
+    <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Users upgrading from older versions can have both versions of Autofill enabled which causes bugs such as the one noted in #767.


## :bulb: Motivation and Context
Fixes #767 

## :green_heart: How did you test it?
Installed debug and release builds, confirmed Password Store is no longer listed as an Accessibility service.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
