### PR TITLE
Improve Git password/passphrase dialog behavior

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
@@ -12,6 +12,7 @@ import android.os.AsyncTask
 import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.PasswordStore
 import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.git.config.SshjSessionFactory
 import net.schmizz.sshj.userauth.UserAuthException
 import org.eclipse.jgit.api.CommitCommand
 import org.eclipse.jgit.api.GitCommand
@@ -147,6 +148,7 @@ class GitAsyncTask(
         if (refreshListOnEnd) {
             (activity as? PasswordStore)?.resetPasswordList()
         }
+        (SshSessionFactory.getInstance() as? SshjSessionFactory)?.clearCredentials()
         SshSessionFactory.setInstance(null)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -26,6 +26,12 @@ fun String.splitLines(): Array<String> {
     return split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 }
 
+fun CharArray.clear() {
+    forEachIndexed { i, _ ->
+        this[i] = 0.toChar()
+    }
+}
+
 fun Context.resolveAttribute(attr: Int): Int {
     val typedValue = TypedValue()
     this.theme.resolveAttribute(attr, typedValue, true)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Improve the behavior of the Git password/passphrase dialog in two ways:
- When the same `InteractivePasswordFinder` is used for authentication twice, e.g., for the push  following a pull in a sync operation, the second prompt should not count as a retry. Otherwise, the remembered passphrase would always be cleared.
- Since we don't want to ask the user for their password/passphrase twice for a single sync operation, the password is now cached for the entire `GitOperation` and cleared in `GitAsyncTask`s `onPostExecute`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #828.

## :green_heart: How did you test it?
I ran a few sync and push operations.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
