### PR TITLE
github: run instrumentation tests against API 30

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2.10.0
       with:
         api-level: ${{ matrix.api-level }}
-        target: default
+        target: google_apis
         script: |
           adb shell settings put global animator_duration_scale 0
           adb shell settings put global transition_animation_scale 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [23, 29]
+        api-level: [23, 29, 30]
         variant: [Debug, Release]
     steps:
 
@@ -71,7 +71,7 @@ jobs:
 
     - name: Run instrumentation tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.10.0
       with:
         api-level: ${{ matrix.api-level }}
         target: default


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Updates the android-emulation-runner action to v2.10.0 to support API 30 as a emulator target.

## :bulb: Motivation and Context
While I do use APS on Android R it's helpful to be able to also verify that with our test suite, which hopefully continues expanding in the future.

## ~~:green_heart: How did you test it?~~

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Moar tests!

