### PR TITLE
github: add flow to purge Cloudflare cache after snapshot deploy

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -66,3 +66,16 @@ jobs:
         SERVER_ADDRESS: ${{ secrets.SERVER_ADDRESS }}
         SERVER_DESTINATION: ${{ secrets.SERVER_DESTINATION }}
         SSH_PORT: ${{ secrets.SSH_PORT }}
+
+    - name: Install NodeJS
+      uses: actions/setup-node@v2-beta
+      with:
+        node-version: '12'
+
+    - name: Install cfcli
+      run: npm install -g cloudflare-cli
+
+    - name: Purge Cloudflare cache
+      run: cfcli --token ${CF_TOKEN} purge "https://dl.msfjarvis.dev/APS/$(cd ./app/build/outputs/apk/release/; ls *.apk)"
+      env:
+        CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Purge the CDN cache for the snapshot build after it is published to ensure the latest version is served to users.


## :bulb: Motivation and Context
To offload bandwidth costs I employ a very generous cache policy to my CDN provider which can often result in an older snapshot build to be served to users because the edge cache has not exceeded its TTL yet. To mitigate this we now purge the file from the CDN cache on each successful deployment to ensure the cache is always up-to-date.

## :green_heart: How did you test it?
Confirmed the `cf-cache-status` header's value changed from `HIT` to `MISS` after the deployment finished executing.


There's not much here to review, just have faith in my ability to overcomplicate DevOps :)