### PR TITLE
UserPreference: delete all shortcuts when repository is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - 'Draw over other apps' permission dialog opens when attempting to use Oreo Autofill
+- Old app shortcuts are now removed when the local repository is deleted
 
 ### Added
 - Completely revamped decypted password view

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -232,6 +232,11 @@ class UserPreference : AppCompatActivity() {
                             // TODO Handle the different cases of exceptions
                         }
 
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                            requireContext().getSystemService<ShortcutManager>()?.apply {
+                                removeDynamicShortcuts(dynamicShortcuts.map { it.id }.toMutableList())
+                            }
+                        }
                         sharedPreferences.edit { putBoolean("repository_initialized", false) }
                         dialogInterface.cancel()
                         callingActivity.finish()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Remove all dynamic shortcuts when the repository is deleted.

## :bulb: Motivation and Context
Fixes #470

## :green_heart: How did you test it?
Haven't so far, working off tethering and laptop doesn't have Java :grimacing:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
