### PR TITLE
PasswordStore: refresh password list on swipe down in non-git mode

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -62,33 +62,29 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     private fun initializePasswordList() {
         val gitDir = File(PasswordRepository.getRepositoryDirectory(requireContext()), ".git")
         val hasGitDir = gitDir.exists() && gitDir.isDirectory && (gitDir.listFiles()?.isNotEmpty() == true)
-        if (hasGitDir) {
-            binding.swipeRefresher.setOnRefreshListener {
-                if (!PasswordRepository.isGitRepo()) {
-                    Snackbar.make(binding.root, getString(R.string.clone_git_repo), Snackbar.LENGTH_INDEFINITE)
-                        .setAction(R.string.clone_button) {
-                            val intent = Intent(context, GitServerConfigActivity::class.java)
-                            intent.putExtra(BaseGitActivity.REQUEST_ARG_OP, BaseGitActivity.REQUEST_CLONE)
-                            startActivityForResult(intent, BaseGitActivity.REQUEST_CLONE)
-                        }
-                        .show()
-                    binding.swipeRefresher.isRefreshing = false
-                } else {
-                    // When authentication is set to ConnectionMode.None then the only git operation we
-                    // can run is a pull, so automatically fallback to that.
-                    val operationId = when (ConnectionMode.fromString(settings.getString("git_remote_auth", null))) {
-                        ConnectionMode.None -> BaseGitActivity.REQUEST_PULL
-                        else -> BaseGitActivity.REQUEST_SYNC
-                    }
-                    val intent = Intent(context, GitOperationActivity::class.java)
-                    intent.putExtra(BaseGitActivity.REQUEST_ARG_OP, operationId)
-                    startActivityForResult(intent, operationId)
-                }
-            }
-        } else {
-            binding.swipeRefresher.setOnRefreshListener {
+        binding.swipeRefresher.setOnRefreshListener {
+            if (!hasGitDir) {
                 requireStore().refreshPasswordList()
                 binding.swipeRefresher.isRefreshing = false
+            } else if (!PasswordRepository.isGitRepo()) {
+                Snackbar.make(binding.root, getString(R.string.clone_git_repo), Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.clone_button) {
+                        val intent = Intent(context, GitServerConfigActivity::class.java)
+                        intent.putExtra(BaseGitActivity.REQUEST_ARG_OP, BaseGitActivity.REQUEST_CLONE)
+                        startActivityForResult(intent, BaseGitActivity.REQUEST_CLONE)
+                    }
+                    .show()
+                binding.swipeRefresher.isRefreshing = false
+            } else {
+                // When authentication is set to ConnectionMode.None then the only git operation we
+                // can run is a pull, so automatically fallback to that.
+                val operationId = when (ConnectionMode.fromString(settings.getString("git_remote_auth", null))) {
+                    ConnectionMode.None -> BaseGitActivity.REQUEST_PULL
+                    else -> BaseGitActivity.REQUEST_SYNC
+                }
+                val intent = Intent(context, GitOperationActivity::class.java)
+                intent.putExtra(BaseGitActivity.REQUEST_ARG_OP, operationId)
+                startActivityForResult(intent, operationId)
             }
         }
 

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -85,6 +85,11 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
                     startActivityForResult(intent, operationId)
                 }
             }
+        } else {
+            binding.swipeRefresher.setOnRefreshListener {
+                requireStore().refreshPasswordList()
+                binding.swipeRefresher.isRefreshing = false
+            }
         }
 
         recyclerAdapter = PasswordItemRecyclerAdapter()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Refreshes the password list when swipe refresh is triggered and our repository does not have a `.git` directory.

## :bulb: Motivation and Context
Currently if there is no `.git` directory in the store, the swipe refresher will simply start the refresh animation
and stay stuck doing it, which is not good UX and also wasteful.

## :green_heart: How did you test it?
Create a non-git repository, pull down on password list and see it refresh and stop the animation.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Still need to reproduce and solve #845
