### PR TITLE
PasswordCreationActivity: properly guard rename code

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -286,7 +286,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                 }
                             }
 
-                            if (category.isVisible && category.isEnabled) {
+                            if (category.isVisible && category.isEnabled && oldFileName != null) {
                                 val oldFile = File("$repoPath/${oldCategory?.trim('/')}/$oldFileName.gpg")
                                 if (oldFile.path != file.path && !oldFile.delete()) {
                                     setResult(RESULT_CANCELED)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
To accomodate for the case where PasswordCreationActivity is used to rename an existing password, we
have checks that attempt to delete the existing file. This is improperly guarded on the category
view being enabled, which is true for both editing as well as autofill password generation. However,
generating a new password through autofill correctly does not pass EXTRA_FILE_NAME which means we
attempt to delete a non-existent file (null.gpg) and thus fail, breaking the save flow.

## :bulb: Motivation and Context
Fixes #866

## :green_heart: How did you test it?
Attempt to generate a password through Autofill, observe that it is correctly committed, created and filled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
