### PR TITLE
Replace YAML with HTML in F-Droid fastlane summary

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,13 +1,13 @@
-Simple password manager that is compatible with [https://www.passwordstore.org/
-pass]: Passwords are stored in simple text files which are encrypted with
-OpenPGP.
+Simple password manager that is compatible with <a href="https://www.passwordstore.org/">pass</a>: Passwords are stored in simple text files which are encrypted with OpenPGP.
 
-Requires [[org.sufficientlysecure.keychain]] to encrypt and decrypt passwords.
+Requires <a href="https://f-droid.org/en/packages/org.sufficientlysecure.keychain/">OpenKeychain</a> to encrypt and decrypt passwords.
 
-'''Features:'''
+<strong>Features:</strong>
 
-* Clone an existing pass repository or start a new one
-* Create and organize password files
-* Sync with a remote Git repository
-* Decrypt and copy passwords
-* Automatically fill and save credentials in apps and supported browsers
+<ul>
+<li>Clone an existing pass repository or start a new one</li>
+<li>Create and organize password files</li>
+<li>Sync with a remote Git repository</li>
+<li>Decrypt and copy passwords</li>
+<li>Automatically fill and save credentials in apps and supported browsers</li>
+</ul>


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
When using the fastlane structure, F-Droid requires summaries to be marked up with HTML instead of YAML.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://gitlab.com/fdroid/fdroiddata/-/merge_requests/6844#note_365752950

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
